### PR TITLE
feature: benchmark-analyzer accepts max group size

### DIFF
--- a/benchmark_analyzer/src/benchmark_analyzer/arguments.rs
+++ b/benchmark_analyzer/src/benchmark_analyzer/arguments.rs
@@ -23,6 +23,10 @@ pub struct Arguments {
     /// The output file. If unset, the result is printed to `stdout`.
     #[structopt(short = "o", long = "output-file")]
     pub output_path: Option<PathBuf>,
+
+    /// Maximum number of results displayed in a group.
+    #[structopt(short = "gm", long = "group-max", default_value = "100")]
+    pub group_max: usize,
 }
 
 impl Arguments {

--- a/benchmark_analyzer/src/benchmark_analyzer/main.rs
+++ b/benchmark_analyzer/src/benchmark_analyzer/main.rs
@@ -24,7 +24,7 @@ fn main() -> anyhow::Result<()> {
             let mut file = std::fs::File::create(output_path)?;
             for (group_name, mut results) in groups_results.into_iter() {
                 results.sort_worst();
-                results.print_worst_results(100, group_name);
+                results.print_worst_results(arguments.group_max, group_name);
                 results.write_all(&mut file, group_name)?;
                 writeln!(file)?;
                 println!();
@@ -35,7 +35,7 @@ fn main() -> anyhow::Result<()> {
             let mut stdout = std::io::stdout();
             for (group_name, mut results) in groups_results.into_iter() {
                 results.sort_worst();
-                results.print_worst_results(100, group_name);
+                results.print_worst_results(arguments.group_max, group_name);
                 results.write_all(&mut stdout, group_name)?;
                 writeln!(stdout)?;
                 println!();


### PR DESCRIPTION
# What ❔

The maximal size of an individual group displayed by benchmark analyzer is not fixed to 100 now but can be passed through CLI. 

## Why ❔

Easier than remove too many examples in each category manually or via a script.
 