### PR TITLE
feat: create a subdirectory per mode in debug/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -197,12 +197,13 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -501,7 +502,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#4ae31ed6286da78869dc76a2ff851590443a81da"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#94d110f5061e8ef9b14db964ed32ee974cceacb2"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -523,7 +524,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#e6486e75696ad5e1b0c3eba8e6345f4c0943d3a0"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#fab586681524407644c155dd22e36cd65b9fdee2"
 dependencies = [
  "anyhow",
  "colored",
@@ -552,7 +553,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#6dfea3cd96a56d220aaf9083e32c3eb411c486b8"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#8fc8c76e4592f7b16619ab9b76a8f38521f54e4b"
 dependencies = [
  "anyhow",
  "colored",
@@ -758,7 +759,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1101,7 +1102,7 @@ source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#c0821d
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1127,9 +1128,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -1414,7 +1415,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1510,7 +1511,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1600,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -1883,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "e3cc72858054fcff6d7dea32df2aeaee6a7c24227366d7ea429aada2f26b16ad"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -1896,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring",
@@ -2030,7 +2031,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2240,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2302,22 +2303,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2436,7 +2437,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2576,7 +2577,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -2610,7 +2611,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#94d110f5061e8ef9b14db964ed32ee974cceacb2"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#4ae31ed6286da78869dc76a2ff851590443a81da"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#fab586681524407644c155dd22e36cd65b9fdee2"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#e6486e75696ad5e1b0c3eba8e6345f4c0943d3a0"
 dependencies = [
  "anyhow",
  "colored",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
 dependencies = [
  "unicode-ident",
 ]

--- a/compiler_tester/src/lib.rs
+++ b/compiler_tester/src/lib.rs
@@ -122,7 +122,7 @@ impl CompilerTester {
                 let mode_string = mode.clone().to_string();
                 let specialized_debug_config = self
                     .debug_config
-                    .clone()
+                    .as_ref()
                     .and_then(|config| config.create_subdirectory(mode_string.as_str()).ok());
                 if let Some(test) = test.build_for_eravm(
                     mode,
@@ -151,7 +151,7 @@ impl CompilerTester {
                 let mode_string = mode.clone().to_string();
                 let specialized_debug_config = self
                     .debug_config
-                    .clone()
+                    .as_ref()
                     .and_then(|config| config.create_subdirectory(mode_string.as_str()).ok());
                 if let Some(test) = test.build_for_evm(
                     mode,

--- a/compiler_tester/src/lib.rs
+++ b/compiler_tester/src/lib.rs
@@ -119,12 +119,17 @@ impl CompilerTester {
         let _: Vec<()> = tests
             .into_par_iter()
             .map(|(test, compiler, mode)| {
+                let mode_string = mode.clone().to_string();
+                let specialized_debug_config = self
+                    .debug_config
+                    .clone()
+                    .and_then(|config| config.create_subdirectory(mode_string.as_str()).ok());
                 if let Some(test) = test.build_for_eravm(
                     mode,
                     compiler,
                     self.summary.clone(),
                     &self.filters,
-                    self.debug_config.clone(),
+                    specialized_debug_config,
                 ) {
                     test.run::<D, M>(self.summary.clone(), vm.clone());
                 }
@@ -143,12 +148,17 @@ impl CompilerTester {
         let _: Vec<()> = tests
             .into_par_iter()
             .map(|(test, compiler, mode)| {
+                let mode_string = mode.clone().to_string();
+                let specialized_debug_config = self
+                    .debug_config
+                    .clone()
+                    .and_then(|config| config.create_subdirectory(mode_string.as_str()).ok());
                 if let Some(test) = test.build_for_evm(
                     mode,
                     compiler,
                     self.summary.clone(),
                     &self.filters,
-                    self.debug_config.clone(),
+                    specialized_debug_config,
                 ) {
                     test.run(self.summary.clone());
                 }

--- a/compiler_tester/src/lib.rs
+++ b/compiler_tester/src/lib.rs
@@ -119,7 +119,7 @@ impl CompilerTester {
         let _: Vec<()> = tests
             .into_par_iter()
             .map(|(test, compiler, mode)| {
-                let mode_string = mode.clone().to_string();
+                let mode_string = mode.to_string();
                 let specialized_debug_config = self
                     .debug_config
                     .as_ref()
@@ -148,7 +148,7 @@ impl CompilerTester {
         let _: Vec<()> = tests
             .into_par_iter()
             .map(|(test, compiler, mode)| {
-                let mode_string = mode.clone().to_string();
+                let mode_string = mode.to_string();
                 let specialized_debug_config = self
                     .debug_config
                     .as_ref()


### PR DESCRIPTION
# What ❔

**Merging this PR requires merging https://github.com/matter-labs/era-compiler-llvm-context/pull/24 first.**

Support creating subfolders in `debug/`.

## Why ❔

Compiler tester overrides IR dumps if they were produced by launching a test repeatedly with different modes.

This change should not break behavior expected from `era-compiler-llvm-context`.


Initially I wanted to just encode modes in the filenames but it turned out to be very intrusive to the code base (for one, dumping `.yul` files is done by a very different code than dumping everything else). Therefore we are creating a subdirectory per mode.
