### PR TITLE
feat: compiling tests without executing them

### DIFF
--- a/compiler_tester/src/compiler_tester/arguments.rs
+++ b/compiler_tester/src/compiler_tester/arguments.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use structopt::StructOpt;
 
-use compiler_tester::workflow::Workflow;
+use compiler_tester::Workflow;
 
 ///
 /// The compiler tester arguments.

--- a/compiler_tester/src/compiler_tester/arguments.rs
+++ b/compiler_tester/src/compiler_tester/arguments.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 
 use structopt::StructOpt;
 
+use compiler_tester::workflow::Workflow;
+
 ///
 /// The compiler tester arguments.
 ///
@@ -104,9 +106,9 @@ pub struct Arguments {
     #[structopt(long = "llvm-debug-logging")]
     pub llvm_debug_logging: bool,
 
-    /// Builds the test code but does not run tests.
-    #[structopt(long = "build-only")]
-    pub build_only: bool,
+    /// Choose between `build` to compile tests only without running them, and `run` to compile and run them.
+    #[structopt(long = "workflow", default_value = "run")]
+    pub workflow: Workflow,
 }
 
 impl Arguments {

--- a/compiler_tester/src/compiler_tester/arguments.rs
+++ b/compiler_tester/src/compiler_tester/arguments.rs
@@ -103,6 +103,10 @@ pub struct Arguments {
     /// Sets the `debug logging` option in LLVM.
     #[structopt(long = "llvm-debug-logging")]
     pub llvm_debug_logging: bool,
+
+    /// Builds the test code but does not run tests.
+    #[structopt(long = "build-only")]
+    pub build_only: bool,
 }
 
 impl Arguments {

--- a/compiler_tester/src/compiler_tester/main.rs
+++ b/compiler_tester/src/compiler_tester/main.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 use colored::Colorize;
 
 use self::arguments::Arguments;
+use compiler_tester::Workflow;
 
 /// The rayon worker stack size.
 const RAYON_WORKER_STACK_SIZE: usize = 16 * 1024 * 1024;
@@ -92,8 +93,17 @@ fn main_inner(arguments: Arguments) -> anyhow::Result<()> {
 
     let filters = compiler_tester::Filters::new(arguments.paths, arguments.modes, arguments.groups);
 
-    let compiler_tester =
-        compiler_tester::CompilerTester::new(summary.clone(), filters, debug_config.clone())?;
+    let workflow = if arguments.build_only {
+        Workflow::BuildOnly
+    } else {
+        Workflow::BuildAndRun
+    };
+    let compiler_tester = compiler_tester::CompilerTester::new(
+        summary.clone(),
+        filters,
+        debug_config.clone(),
+        workflow,
+    )?;
 
     let binary_download_config_paths = vec![
         arguments

--- a/compiler_tester/src/compiler_tester/main.rs
+++ b/compiler_tester/src/compiler_tester/main.rs
@@ -11,7 +11,6 @@ use std::time::Instant;
 use colored::Colorize;
 
 use self::arguments::Arguments;
-use compiler_tester::Workflow;
 
 /// The rayon worker stack size.
 const RAYON_WORKER_STACK_SIZE: usize = 16 * 1024 * 1024;
@@ -93,16 +92,11 @@ fn main_inner(arguments: Arguments) -> anyhow::Result<()> {
 
     let filters = compiler_tester::Filters::new(arguments.paths, arguments.modes, arguments.groups);
 
-    let workflow = if arguments.build_only {
-        Workflow::BuildOnly
-    } else {
-        Workflow::BuildAndRun
-    };
     let compiler_tester = compiler_tester::CompilerTester::new(
         summary.clone(),
         filters,
         debug_config.clone(),
-        workflow,
+        arguments.workflow,
     )?;
 
     let binary_download_config_paths = vec![

--- a/compiler_tester/src/lib.rs
+++ b/compiler_tester/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod summary;
 pub(crate) mod test;
 pub(crate) mod utils;
 pub(crate) mod vm;
+pub mod workflow;
 
 pub use self::filters::Filters;
 pub use self::llvm_options::LLVMOptions;
@@ -26,6 +27,7 @@ use std::sync::Mutex;
 use itertools::Itertools;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
+use workflow::Workflow;
 
 pub use crate::compilers::eravm::EraVMCompiler;
 pub use crate::compilers::llvm::LLVMCompiler;
@@ -52,16 +54,6 @@ pub const TRACE_DIRECTORY: &str = "./trace/";
 /// The compiler test generic representation.
 ///
 type Test = (Arc<dyn Buildable>, Arc<dyn Compiler>, Mode);
-
-///
-/// Describes sets of actions that compiler tester is able to perform.
-///
-pub enum Workflow {
-    /// Only build tests but not execute them.
-    BuildOnly,
-    /// Build and execute tests.
-    BuildAndRun,
-}
 
 ///
 /// The compiler tester.

--- a/compiler_tester/src/lib.rs
+++ b/compiler_tester/src/lib.rs
@@ -10,11 +10,12 @@ pub(crate) mod summary;
 pub(crate) mod test;
 pub(crate) mod utils;
 pub(crate) mod vm;
-pub mod workflow;
+pub(crate) mod workflow;
 
 pub use self::filters::Filters;
 pub use self::llvm_options::LLVMOptions;
 pub use self::summary::Summary;
+pub use self::workflow::Workflow;
 pub use crate::vm::eravm::deployers::native_deployer::NativeDeployer as EraVMNativeDeployer;
 pub use crate::vm::eravm::deployers::system_contract_deployer::SystemContractDeployer as EraVMSystemContractDeployer;
 pub use crate::vm::eravm::EraVM;
@@ -27,7 +28,6 @@ use std::sync::Mutex;
 use itertools::Itertools;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
-use workflow::Workflow;
 
 pub use crate::compilers::eravm::EraVMCompiler;
 pub use crate::compilers::llvm::LLVMCompiler;

--- a/compiler_tester/src/workflow.rs
+++ b/compiler_tester/src/workflow.rs
@@ -15,12 +15,9 @@ pub enum Workflow {
     BuildAndRun,
 }
 
-// any error type implementing Display is acceptable.
-type ParseError = &'static str;
-
 impl FromStr for Workflow {
-    type Err = ParseError;
-    
+    type Err = &'static str;
+
     fn from_str(day: &str) -> Result<Self, Self::Err> {
         match day {
             "build" => Ok(Workflow::BuildOnly),

--- a/compiler_tester/src/workflow.rs
+++ b/compiler_tester/src/workflow.rs
@@ -1,6 +1,8 @@
 //!
-//! Compiler tester workflows
+//! The compiler tester workflows.
 //!
+
+use std::str::FromStr;
 
 ///
 /// Describes sets of actions that compiler tester is able to perform.
@@ -12,13 +14,13 @@ pub enum Workflow {
     /// Build and execute tests.
     BuildAndRun,
 }
-use std::str::FromStr;
 
 // any error type implementing Display is acceptable.
 type ParseError = &'static str;
 
 impl FromStr for Workflow {
     type Err = ParseError;
+    
     fn from_str(day: &str) -> Result<Self, Self::Err> {
         match day {
             "build" => Ok(Workflow::BuildOnly),

--- a/compiler_tester/src/workflow.rs
+++ b/compiler_tester/src/workflow.rs
@@ -1,0 +1,29 @@
+//!
+//! Compiler tester workflows
+//!
+
+///
+/// Describes sets of actions that compiler tester is able to perform.
+///
+#[derive(Debug)]
+pub enum Workflow {
+    /// Only build tests but not execute them.
+    BuildOnly,
+    /// Build and execute tests.
+    BuildAndRun,
+}
+use std::str::FromStr;
+
+// any error type implementing Display is acceptable.
+type ParseError = &'static str;
+
+impl FromStr for Workflow {
+    type Err = ParseError;
+    fn from_str(day: &str) -> Result<Self, Self::Err> {
+        match day {
+            "build" => Ok(Workflow::BuildOnly),
+            "run" => Ok(Workflow::BuildAndRun),
+            _ => Err("Could not parse workflow. Supported workflows: build, run."),
+        }
+    }
+}

--- a/fuzzer/fuzz_targets/common.rs
+++ b/fuzzer/fuzz_targets/common.rs
@@ -3,8 +3,8 @@ use std::{
     sync::Arc,
 };
 
+use compiler_tester::Workflow;
 use compiler_tester::{Buildable, EthereumTest, Mode, SolidityCompiler, SolidityMode, Summary};
-use compiler_tester::workflow::Workflow;
 pub use solidity_adapter::{
     test::function_call::parser::{
         lexical::token::{
@@ -174,7 +174,7 @@ pub fn build_and_run(test: EthereumTest) -> anyhow::Result<Summary> {
         compiler_tester::Summary::new(true, false).wrap(),
         compiler_tester::Filters::new(vec![], vec![], vec![]),
         None,
-        Workflow::BuildAndRun
+        Workflow::BuildAndRun,
     )?;
     zkevm_tester::runners::compiler_tests::set_tracing_mode(
         zkevm_tester::runners::compiler_tests::VmTracingOptions::from_u64(0),

--- a/fuzzer/fuzz_targets/common.rs
+++ b/fuzzer/fuzz_targets/common.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use compiler_tester::{Buildable, EthereumTest, Mode, SolidityCompiler, SolidityMode, Summary};
+use compiler_tester::{Buildable, EthereumTest, Mode, SolidityCompiler, SolidityMode, Summary, Workflow};
 pub use solidity_adapter::{
     test::function_call::parser::{
         lexical::token::{
@@ -173,6 +173,7 @@ pub fn build_and_run(test: EthereumTest) -> anyhow::Result<Summary> {
         compiler_tester::Summary::new(true, false).wrap(),
         compiler_tester::Filters::new(vec![], vec![], vec![]),
         None,
+        Workflow::BuildAndRun
     )?;
     zkevm_tester::runners::compiler_tests::set_tracing_mode(
         zkevm_tester::runners::compiler_tests::VmTracingOptions::from_u64(0),

--- a/fuzzer/fuzz_targets/common.rs
+++ b/fuzzer/fuzz_targets/common.rs
@@ -3,7 +3,8 @@ use std::{
     sync::Arc,
 };
 
-use compiler_tester::{Buildable, EthereumTest, Mode, SolidityCompiler, SolidityMode, Summary, Workflow};
+use compiler_tester::{Buildable, EthereumTest, Mode, SolidityCompiler, SolidityMode, Summary};
+use compiler_tester::workflow::Workflow;
 pub use solidity_adapter::{
     test::function_call::parser::{
         lexical::token::{


### PR DESCRIPTION
# What ❔

Compiler tester may now build tests without running them. This is useful to dump IRs quickly. 
The CLI interface did not change but now accepts an optional `--workflow=[run|build]` argument, `run` being default. 