### PR TITLE
feat: tests for remaining EVM opcodes

### DIFF
--- a/benchmark_analyzer/src/benchmark/group/results.rs
+++ b/benchmark_analyzer/src/benchmark/group/results.rs
@@ -414,7 +414,10 @@ impl<'a> Results<'a> {
                     })
                     .expect("Always exists");
 
-                let reduction = 100.0 - (candidate_ratio * 100.0 / reference_ratio);
+                let mut reduction = 100.0 - (candidate_ratio * 100.0 / reference_ratio);
+                if reduction < 0.0 { // If candidate_ratio > reference_ratio then we still want to show how much worse it is
+                    reduction *= -1.0;
+                }
                 if reduction >= 0.001 {
                     let is_positive = candidate_ratio < reference_ratio;
                     let is_negative = candidate_ratio > reference_ratio;

--- a/benchmark_analyzer/src/benchmark/mod.rs
+++ b/benchmark_analyzer/src/benchmark/mod.rs
@@ -30,7 +30,7 @@ impl Benchmark {
     pub const EVM_INTERPRETER_GROUP_PREFIX: &'static str = "EVMInterpreter M3B3";
 
     /// The EVM opcodes to test.
-    pub const EVM_OPCODES: [&'static str; 119] = [
+    pub const EVM_OPCODES: [&'static str; 140] = [
         "ADD",
         "MUL",
         "SUB",
@@ -63,6 +63,17 @@ impl Benchmark {
         "ORIGIN",
         "CALLER",
         "CALLVALUE",
+        "CALLDATALOAD",
+        "CALLDATASIZE",
+        "CALLDATACOPY",
+        "CODESIZE",
+        "CODECOPY",
+        "GASPRICE",
+        "EXTCODESIZE",
+        "EXTCODECOPY",
+        "RETURNDATASIZE",
+        "RETURNDATACOPY",
+        "EXTCODEHASH",
         "BLOCKHASH",
         "COINBASE",
         "TIMESTAMP",
@@ -148,7 +159,17 @@ impl Benchmark {
         "SWAP14",
         "SWAP15",
         "SWAP16",
+        "LOG0",
+        "LOG1",
+        "LOG2",
+        "LOG3",
+        "LOG4",
+        "CREATE",
+        "CALL",
         "RETURN",
+        "DELEGATECALL",
+        "STATICCALL",
+        "CREATE2",
         "REVERT",
     ];
 
@@ -165,6 +186,7 @@ impl Benchmark {
             };
 
             let mut group_results = Group::compare(reference_group, candidate_group);
+            println!("group geomin {}", group_results.ergs_mean);
             if group_name.starts_with(Self::EVM_INTERPRETER_GROUP_PREFIX) {
                 if let (Some(reference_ratios), Some(candidate_ratios)) = (
                     reference

--- a/benchmark_analyzer/src/benchmark/mod.rs
+++ b/benchmark_analyzer/src/benchmark/mod.rs
@@ -30,7 +30,7 @@ impl Benchmark {
     pub const EVM_INTERPRETER_GROUP_PREFIX: &'static str = "EVMInterpreter M3B3";
 
     /// The EVM opcodes to test.
-    pub const EVM_OPCODES: [&'static str; 140] = [
+    pub const EVM_OPCODES: [&'static str; 135] = [
         "ADD",
         "MUL",
         "SUB",
@@ -159,11 +159,6 @@ impl Benchmark {
         "SWAP14",
         "SWAP15",
         "SWAP16",
-        "LOG0",
-        "LOG1",
-        "LOG2",
-        "LOG3",
-        "LOG4",
         "CREATE",
         "CALL",
         "RETURN",

--- a/compiler_tester/src/directories/matter_labs/test/metadata/evm_contract.rs
+++ b/compiler_tester/src/directories/matter_labs/test/metadata/evm_contract.rs
@@ -18,13 +18,16 @@ impl EVMContract {
     /// Returns the init code.
     ///
     pub fn init_code(&self, size: usize) -> String {
-        format!("608060405234801561000f575f80fd5b50{}8061001c5f395ff3fe", if size <= 0xff {
-            format!("60{:02x}", size)
-        } else if size <= 0xffff {
-            format!("61{:04x}", size)
-        } else {
+        if size > 0xffff {
             panic!("The bytecode is too large");
-        })
+        }
+        let mut code_size = format!("60{:02x}", size);
+        let mut codecopy_index = "1c";
+        if size > 0xff {
+            code_size = format!("61{:04x}", size);
+            codecopy_index = "1d";
+        }
+        format!("608060405234801561000f575f80fd5b50{}806100{}5f395ff3fe", code_size, codecopy_index)
     }
 
     ///

--- a/compiler_tester/src/directories/matter_labs/test/mod.rs
+++ b/compiler_tester/src/directories/matter_labs/test/mod.rs
@@ -310,15 +310,16 @@ impl MatterLabsTest {
             .metadata
             .evm_contracts
             .keys()
-            .filter(|name| name.contains("Template") || name.contains("Full"))
+            .filter(|name| name.contains("Template") || name.contains("Full") || name.contains("Before"))
             .cloned()
             .collect();
         evm_contracts.sort();
 
-        let mut metadata_cases = Vec::with_capacity(evm_contracts.len() / 2);
-        for pair_of_bytecodes in evm_contracts.chunks(2) {
-            let full = &pair_of_bytecodes[0];
-            let template = &pair_of_bytecodes[1];
+        let mut metadata_cases = Vec::with_capacity(evm_contracts.len() / 3);
+        for pair_of_bytecodes in evm_contracts.chunks(3) {
+            let before = &pair_of_bytecodes[0];
+            let full = &pair_of_bytecodes[1];
+            let template = &pair_of_bytecodes[2];
             let exception = full.contains("REVERT");
 
             metadata_cases.push(MatterLabsCase {
@@ -329,6 +330,23 @@ impl MatterLabsTest {
                     .to_owned(),
                 modes: None,
                 inputs: vec![
+                    MatterLabsCaseInput {
+                        comment: None,
+                        instance: "Proxy".to_owned(),
+                        caller: default_caller_address(),
+                        method: "#fallback".to_owned(),
+                        calldata: MatterLabsCaseInputCalldata::List(vec![
+                            "Benchmark.address".to_owned(),
+                            format!("{before}.address"),
+                        ]),
+                        value: None,
+                        storage: HashMap::new(),
+                        expected: Some(
+                            MatterLabsCaseInputExpected::successful_evm_interpreter_benchmark(
+                                false,
+                            ),
+                        ),
+                    },
                     MatterLabsCaseInput {
                         comment: None,
                         instance: "Proxy".to_owned(),


### PR DESCRIPTION
# What ❔

This PR adds the code necessary to perform the tests of the rest of the opcodes added on this [PR](https://github.com/matter-labs/era-compiler-tests/pull/29)

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

The Before case for the tests was added because when you tried to write a test that needed to create a contract, since the Template and Full share the vm instance, they both created the same contract, so the decommiter failed since it already knew the hash, that's why the Before test was added, in order to run the contract creation in it before Template and Full, so that the gas comparisons were still correct (instead of creating the contract on Template and not in Full, since that way a specific opcode gas would not be tested)
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
