### PR TITLE
fix: skip tx number in storage_changes

### DIFF
--- a/compiler_tester/src/vm/eravm/vm2_adapter.rs
+++ b/compiler_tester/src/vm/eravm/vm2_adapter.rs
@@ -110,7 +110,7 @@ pub fn run_vm(
                 .world_diff
                 .get_storage_state()
                 .iter()
-                .map(|(&(address, key), value)| {
+                .map(|(&(address, key), (_, value))| {
                     (StorageKey { address, key }, H256::from_uint(value))
                 })
                 .collect::<HashMap<_, _>>();
@@ -118,7 +118,7 @@ pub fn run_vm(
                 .world_diff
                 .get_storage_state()
                 .iter()
-                .filter_map(|((address, key), value)| {
+                .filter_map(|((address, key), (_, value))| {
                     if *address == *zkevm_assembly::zkevm_opcode_defs::system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS {
                         let mut buffer = [0u8; 32];
                         key.to_big_endian(&mut buffer);


### PR DESCRIPTION
# What ❔

Support the new `storage_changes` data structure.

## Why ❔

To fix the build error when using the `vm2` feature.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
