### PR TITLE
fix: optimize RAM usage in zksolc and zkvyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -508,7 +508,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#da780bbb2ccf4b4ef0f66f3e67268fdcfb9adcfc"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9969de17367fc850cd2c7fc82dc26a4ade550a05"
 dependencies = [
  "anyhow",
  "serde",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#f63506726725f8940e02e5b3d345032b46046933"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#06ab4ba440469129da02cb578e3ebd06feb380d3"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -774,7 +774,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1117,7 +1117,7 @@ source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#c0821d
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1428,7 +1428,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1486,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1551,7 +1551,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2079,7 +2079,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2289,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2366,7 +2366,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2484,7 +2484,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2591,7 +2591,7 @@ checksum = "2266fcb904c50fb17fda4c9a751a1715629ecf8b21f4c9d78b4890fb71525d71"
 [[package]]
 name = "vm2"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vm2#e683ae8e600bfae85415edbdfcea0b727f462f4c"
+source = "git+https://github.com/matter-labs/vm2#8defb4ad9643b87151e00030166f90763bcf356d"
 dependencies = [
  "enum_dispatch",
  "primitive-types",
@@ -2635,7 +2635,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -2669,7 +2669,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2952,7 +2952,7 @@ checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 [[package]]
 name = "zk_evm"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-zk_evm?branch=v1.5.0#9bbf7ffd2c38ee8b9667e96eaf0c111037fe976f"
+source = "git+https://github.com/matter-labs/era-zk_evm?branch=v1.5.0#0c5cdca00cca4fa0a8c49147a11048c24f8a4b12"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "zkevm-assembly"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly?branch=v1.5.0#2faea98303377cad71f4c7d8dacb9c6546874602"
+source = "git+https://github.com/matter-labs/era-zkEVM-assembly?branch=v1.5.0#48303aa435810adb12e277494e5dae3764313330"
 dependencies = [
  "env_logger",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-optimize-ram-usage#9d2f1e4d4f9345495ddc92ec009afe9ce76adaf8"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-optimize-ram-usage#0b32df7067d7b93d39b9fc40ebc09150f2f68907"
 dependencies = [
  "anyhow",
  "colored",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-optimize-ram-usage#f6ad9e06e2b5704328195d7c0fd0d9d28e259be3"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-optimize-ram-usage#4bbba113d825a0681818bfab0ccd23defd6a2fb2"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-optimize-ram-usage#0b32df7067d7b93d39b9fc40ebc09150f2f68907"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#7d221b10df928b6dbfcfc0f1c004119b176604e4"
 dependencies = [
  "anyhow",
  "colored",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-optimize-ram-usage#4bbba113d825a0681818bfab0ccd23defd6a2fb2"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#5f371e516e3c573ab3626ab7cbb0ccb34b1d2bbe"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#dd81ee9c02d5fa5905d2461df1966215052f7923"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-optimize-ram-usage#9d2f1e4d4f9345495ddc92ec009afe9ce76adaf8"
 dependencies = [
  "anyhow",
  "colored",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#973230cde15e29eb91277c2cfcc86c7b3f33dde6"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-optimize-ram-usage#f6ad9e06e2b5704328195d7c0fd0d9d28e259be3"
 dependencies = [
  "anyhow",
  "colored",

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -47,8 +47,8 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-optimize-ram-usage" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-optimize-ram-usage" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }
 # era-compiler-llvm-context = { path = "../../era-compiler-llvm-context" }

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -43,13 +43,12 @@ evm = { git = "https://github.com/rust-ethereum/evm", branch = "master" }
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.5.0" }
 zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs", branch = "v1.5.0" }
 zkevm_tester = { git = "https://github.com/matter-labs/era-zkevm_tester", branch = "v1.5.0" }
-
 vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-optimize-ram-usage" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-optimize-ram-usage" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }
 # era-compiler-llvm-context = { path = "../../era-compiler-llvm-context" }

--- a/compiler_tester/src/compilers/solidity/mod.rs
+++ b/compiler_tester/src/compilers/solidity/mod.rs
@@ -200,7 +200,7 @@ impl SolidityCompiler {
             None
         };
 
-        let solc_input = era_compiler_solidity::SolcStandardJsonInput::try_from_sources(
+        let solc_input = era_compiler_solidity::SolcStandardJsonInput::try_from_solidity_sources(
             evm_version,
             sources.iter().cloned().collect(),
             libraries.clone(),

--- a/compiler_tester/src/compilers/yul/mod.rs
+++ b/compiler_tester/src/compilers/yul/mod.rs
@@ -46,12 +46,15 @@ impl Compiler for YulCompiler {
     ) -> anyhow::Result<EraVMInput> {
         let mode = YulMode::unwrap(mode);
 
-        let mut solc_compiler = if mode.is_system_mode {
+        let solc_version = if mode.is_system_mode {
             None
         } else {
-            Some(SolidityCompiler::executable(
-                &era_compiler_solidity::SolcCompiler::LAST_SUPPORTED_VERSION,
-            )?)
+            Some(
+                SolidityCompiler::executable(
+                    &era_compiler_solidity::SolcCompiler::LAST_SUPPORTED_VERSION,
+                )?
+                .version()?,
+            )
         };
 
         let last_contract = sources
@@ -63,7 +66,7 @@ impl Compiler for YulCompiler {
         let project = era_compiler_solidity::Project::try_from_yul_sources(
             sources.into_iter().collect(),
             BTreeMap::new(),
-            solc_compiler.as_mut(),
+            solc_version,
             debug_config.as_ref(),
         )?;
 
@@ -102,9 +105,12 @@ impl Compiler for YulCompiler {
     ) -> anyhow::Result<EVMInput> {
         let mode = YulMode::unwrap(mode);
 
-        let mut solc_compiler = Some(SolidityCompiler::executable(
-            &era_compiler_solidity::SolcCompiler::LAST_SUPPORTED_VERSION,
-        )?);
+        let solc_version = Some(
+            SolidityCompiler::executable(
+                &era_compiler_solidity::SolcCompiler::LAST_SUPPORTED_VERSION,
+            )?
+            .version()?,
+        );
 
         let last_contract = sources
             .last()
@@ -115,7 +121,7 @@ impl Compiler for YulCompiler {
         let project = era_compiler_solidity::Project::try_from_yul_sources(
             sources.into_iter().collect(),
             BTreeMap::new(),
-            solc_compiler.as_mut(),
+            solc_version,
             debug_config.as_ref(),
         )?;
 

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -34,7 +34,7 @@ zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", br
 zkevm_tester = { git = "https://github.com/matter-labs/era-zkevm_tester", branch = "v1.5.0" }
 
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-optimize-ram-usage" }
 
 compiler-tester = { path = "../compiler_tester" }
 solidity-adapter = { path = "../solidity_adapter" }

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -34,7 +34,7 @@ zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", br
 zkevm_tester = { git = "https://github.com/matter-labs/era-zkevm_tester", branch = "v1.5.0" }
 
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-optimize-ram-usage" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
 
 compiler-tester = { path = "../compiler_tester" }
 solidity-adapter = { path = "../solidity_adapter" }


### PR DESCRIPTION
# What ❔

1. Optimizes the RAM usage while running recursive child processes of itself.
2. Includes an LLVM fix for the GVN/NewGVN optimizer pass.

## Why ❔

The RAM usage with large projects was over the top and caused OOM.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
