### PR TITLE
chore: zkevm -> eravm, y -> I

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tests"]
 	path = tests
 	url = https://github.com/matter-labs/era-compiler-tests
-	branch = main
+	branch = az-cpr-1711-weird-behavior-of-the-debug-folder-in-compiler-tester
 [submodule "solidity"]
 	path = solidity
 	url = https://github.com/ethereum/solidity

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tests"]
 	path = tests
 	url = https://github.com/matter-labs/era-compiler-tests
-	branch = az-cpr-1711-weird-behavior-of-the-debug-folder-in-compiler-tester
+	branch = main
 [submodule "solidity"]
 	path = solidity
 	url = https://github.com/ethereum/solidity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-cpr-1718-turn-underlying-compilers-into-singletons#3427866df42c0dbeaac5fa45391301cd92746e0c"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#b6aee421856c54ba4d78c6a5ace0d6db2715cf78"
 dependencies = [
  "anyhow",
  "colored",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-cpr-1718-turn-underlying-compilers-into-singletons#ee1c327ad99c3d78e4698333fd702905eb750aee"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#e379645966210c28ed1aa9b4e436f06202e0fab7"
 dependencies = [
  "anyhow",
  "colored",

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ When the build succeeds, you can run the tests using [the examples below](#usage
 ### Solidity codegens
 
 - Yul pure (`Y`)
-- EVM assembly from Yul (`y`)
+- EVM assembly from Yul (`I`)
 - EVM assembly pure (`E`)
 - Vyper LLL (`V`)
 

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -47,8 +47,8 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-cpr-1718-turn-underlying-compilers-into-singletons" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-cpr-1718-turn-underlying-compilers-into-singletons" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }
 # era-compiler-llvm-context = { path = "../../era-compiler-llvm-context" }

--- a/compiler_tester/src/compilers/mode/mod.rs
+++ b/compiler_tester/src/compilers/mode/mod.rs
@@ -151,10 +151,10 @@ impl Mode {
                 .replace_all(current.as_str(), "E*")
                 .to_string();
         }
-        if filter.contains("y*") {
-            current = regex::Regex::new("y[-+]")
+        if filter.contains("I*") {
+            current = regex::Regex::new("I[-+]")
                 .expect("Always valid")
-                .replace_all(current.as_str(), "y*")
+                .replace_all(current.as_str(), "I*")
                 .to_string();
         }
         if filter.contains("V*") {

--- a/compiler_tester/src/compilers/solidity/mode.rs
+++ b/compiler_tester/src/compilers/solidity/mode.rs
@@ -134,7 +134,7 @@ impl std::fmt::Display for Mode {
             "{}{}{} {}",
             match self.solc_pipeline {
                 era_compiler_solidity::SolcPipeline::Yul => "Y",
-                era_compiler_solidity::SolcPipeline::EVMLA if self.via_ir => "y",
+                era_compiler_solidity::SolcPipeline::EVMLA if self.via_ir => "I",
                 era_compiler_solidity::SolcPipeline::EVMLA => "E",
             },
             if self.solc_optimize { '+' } else { '-' },

--- a/compiler_tester/src/compilers/solidity/upstream/mode.rs
+++ b/compiler_tester/src/compilers/solidity/upstream/mode.rs
@@ -116,7 +116,7 @@ impl std::fmt::Display for Mode {
             "{}{} {}",
             match self.solc_pipeline {
                 era_compiler_solidity::SolcPipeline::Yul => "Y",
-                era_compiler_solidity::SolcPipeline::EVMLA if self.via_ir => "y",
+                era_compiler_solidity::SolcPipeline::EVMLA if self.via_ir => "I",
                 era_compiler_solidity::SolcPipeline::EVMLA => "E",
             },
             if self.solc_optimize { '+' } else { '-' },

--- a/compiler_tester/src/lib.rs
+++ b/compiler_tester/src/lib.rs
@@ -96,7 +96,7 @@ impl CompilerTester {
     const LLVM_SIMPLE: &'static str = "tests/llvm";
 
     /// The EraVM simple tests directory.
-    const ERAVM_SIMPLE: &'static str = "tests/zkevm";
+    const ERAVM_SIMPLE: &'static str = "tests/eravm";
 }
 
 impl CompilerTester {

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -34,7 +34,7 @@ zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", br
 zkevm_tester = { git = "https://github.com/matter-labs/era-zkevm_tester", branch = "v1.5.0" }
 
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-cpr-1718-turn-underlying-compilers-into-singletons" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
 
 compiler-tester = { path = "../compiler_tester" }
 solidity-adapter = { path = "../solidity_adapter" }


### PR DESCRIPTION
# What ❔

1. Renames the `y` mode to `I`.
2. Renames the `zkevm` folder to `eravm`.

## Why ❔

1. It conflicts with `Y` when dumping the debug output, because folder names cannot be case-sensitive.
2. The old name is obsolete.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
