### PR TITLE
chore: add ci solc reference config for benchmarks

### DIFF
--- a/configs/solc-bin-ci-reference.json
+++ b/configs/solc-bin-ci-reference.json
@@ -1,0 +1,16 @@
+{
+  "binaries": {
+    "${SOLC_VERSION}": {
+      "is_enabled": true,
+      "protocol": "https",
+      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}/solc-${PLATFORM}-${VERSION}-${ZKSYNC_REVISION}",
+      "destination": "./solc-bin/solc-${VERSION}"
+    }
+  },
+  "platforms": {
+    "linux-amd64": "linux-amd64",
+    "linux-arm64": "linux-arm64",
+    "macos-amd64": "macosx-amd64",
+    "macos-arm64": "macosx-arm64"
+  }
+}


### PR DESCRIPTION
# What ❔

Add `solc` reference config for benchmarks.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Unfortunately, one reference config for `solc` benchmarks is required to download any base reference of the `solc` compiler dynamically, because only a few versions are enabled for downloading in the default config file.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
