### PR TITLE
feat: remove EVM interpreter runtime code repeats

### DIFF
--- a/compiler_tester/src/directories/matter_labs/test/metadata/evm_contract.rs
+++ b/compiler_tester/src/directories/matter_labs/test/metadata/evm_contract.rs
@@ -14,9 +14,6 @@ pub struct EVMContract {
 }
 
 impl EVMContract {
-    /// The number of pattern reruns to provide more accurate benchmarks.
-    pub const RUNTIME_CODE_REPEATS: usize = 32;
-
     ///
     /// Returns the init code.
     ///
@@ -39,13 +36,7 @@ impl EVMContract {
     ///
     /// Returns the runtime code.
     ///
-    pub fn runtime_code(&self, instruction_name: &str) -> String {
-        let repeats = match instruction_name {
-            "RETURNDATASIZE" | "RETURNDATACOPY" | "EXTCODESIZE" | "EXTCODEHASH" | "EXTCODECOPY"
-            | "CALL" | "STATICCALL" | "DELEGATECALL" | "CREATE" | "CREATE2" => 1,
-            _ => Self::RUNTIME_CODE_REPEATS,
-        };
-
-        format!("{}00", self.runtime_code.repeat(repeats))
+    pub fn runtime_code(&self) -> String {
+        format!("{}00", self.runtime_code)
     }
 }

--- a/compiler_tester/src/directories/matter_labs/test/mod.rs
+++ b/compiler_tester/src/directories/matter_labs/test/mod.rs
@@ -262,8 +262,7 @@ impl MatterLabsTest {
         let mut instances = BTreeMap::new();
 
         for (instance, evm_contract) in self.metadata.evm_contracts.iter() {
-            let instruction_name = instance.split('_').next().expect("Always exists");
-            let runtime_code = evm_contract.runtime_code(instruction_name);
+            let runtime_code = evm_contract.runtime_code();
             let mut bytecode = evm_contract.init_code(runtime_code.len());
             bytecode.push_str(runtime_code.as_str());
 


### PR DESCRIPTION
# What ❔

Executes each opcode test's runtime code only once.

## Why ❔

After the removal of proxies, this may be redundant, but let's see the benchmarks.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
