### PR TITLE
ci: fix ccache regeneration workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,3 +39,4 @@ jobs:
       compiler_llvm_benchmark_mode: ${{ github.event.inputs.compiler_llvm_benchmark_mode || '^M^B3' }}
       compiler_llvm_benchmark_path: ${{ github.event.inputs.compiler_llvm_benchmark_path || '' }}
       compiler-tester-repo: ${{ github.event.pull_request.head.repo.full_name }}
+      ccache-key-type: static

--- a/.github/workflows/ccache-regen.yml
+++ b/.github/workflows/ccache-regen.yml
@@ -3,7 +3,7 @@ name: Regenerate ccache
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *' # every month
+    - cron: '0 0 1 * *' # every month
 
 concurrency:
   group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.sha }}
@@ -18,10 +18,14 @@ jobs:
       options: -m 110g
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Build LLVM
-        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@main
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
           extra-args: "\\-DLLVM_ENABLE_WERROR=On \\-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
           enable-tests: true
           enable-assertions: true
+          ccache-key-type: static
           save-ccache: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,3 +27,4 @@ jobs:
     secrets: inherit
     with:
       compiler-tester-repo: ${{ github.event.pull_request.head.repo.full_name }} # required to properly test forks
+      ccache-key-type: static


### PR DESCRIPTION
# What ❔

* [x] Fix ccache regeneration error with `checkout`
* [x] Uses `static` type of cache regenerated monthly, because we're using `main` branch in `LLVM.lock` here 
* [x] Fix trigger to once per month

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Test workflow is [here](https://github.com/matter-labs/era-compiler-tester/actions/runs/9467920030).

## Why ❔

Additional checkout was required for `LLVM.lock`.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
