### PR TITLE
ci: support workflow with sanitizers

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,81 @@
+name: Sanitizers tests
+
+on:
+  workflow_call:
+    inputs:
+      # For more information about the supported sanitizers in Rust, see:
+      # https://rustc-dev-guide.rust-lang.org/sanitizers.html
+      rust-sanitizer:
+        required: false
+        default: 'address'
+        type: string
+        description: 'A sanitizer to build Rust code with. Possible values are: address, cfi, hwaddress, kcfi, leak, memory or thread'
+      # For more information about the supported sanitizers in LLVM, see `LLVM_USE_SANITIZER` option in:
+      # https://www.llvm.org/docs/CMake.html
+      llvm-sanitizer:
+        required: false
+        default: 'Address'
+        type: string
+        description: 'A sanitizer to build LLVM with. Possible values are Address, Memory, MemoryWithOrigins, Undefined, Thread, DataFlow, and Address;Undefined'
+      path:
+        required: false
+        type: string
+        default: 'tests/solidity'
+        description: 'Path filter of the era-compiler-tester. For example: tests/solidity/simple'
+      mode:
+        required: false
+        type: string
+        default: 'Y+M3B3 0.8.26'
+        description: 'Mode filter for the era-compiler-tester. For example: Y+M3B3 0.8.26'
+
+jobs:
+  run-with-sanitizers:
+    runs-on: ci-runner-compiler
+    container:
+      image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+      options: -m 110g
+    env:
+      TARGET: x86_64-unknown-linux-gnu
+    steps:
+
+      - name: Checkout compiler-tester
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build LLVM
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          builder-extra-args: "--sanitizer ${{ inputs.llvm-sanitizer }}"
+          enable-assertions: true
+
+      - name: Install rustc nightly
+        run: |
+          rustup install nightly-${TARGET}
+          rustup component add rust-src --toolchain nightly-${TARGET}
+
+      - name: Build compiler-tester
+        env:
+          RUSTFLAGS: "-Z sanitizer=${{ inputs.rust-sanitizer }}"
+        run: cargo +nightly build --release --target ${TARGET} -Zbuild-std --bin 'compiler-tester'
+
+      - name: Build zksolc and zkvyper
+        env:
+          CARGO_CHECKOUT_DIR: /usr/local/cargo/git/checkouts
+          RUSTFLAGS: "-Z sanitizer=${{ inputs.rust-sanitizer }}"
+        run: |
+          cargo +nightly build --release --target ${TARGET} -Zbuild-std \
+            --manifest-path ${CARGO_CHECKOUT_DIR}/era-compiler-solidity-*/*/Cargo.toml \
+            --target-dir './target-zksolc/'
+          cargo +nightly build --release --target ${TARGET} -Zbuild-std \
+            --manifest-path ${CARGO_CHECKOUT_DIR}/era-compiler-vyper-*/*/Cargo.toml \
+            --target-dir './target-zkvyper/'
+
+      - name: Run tests with sanitizers
+        run: |
+          set -x
+          ./target/${TARGET}/release/compiler-tester \
+            --zksolc "./target-zksolc/${TARGET}/release/zksolc" \
+            --zkvyper "./target-zkvyper/${TARGET}/release/zkvyper" \
+            --path '${{ inputs.path }}'
+            --mode '${{ inputs.mode }}'


### PR DESCRIPTION
# What ❔

Add manual workflow to run `compiler-tester` with sanitizers enabled.

The workflow is working as follows:
1. Build LLVM with sanitizer specified with `llvm-sanitizer` parameter
2. Build FE compilers with sanitizer specified with `rust-sanitizer` parameter
3. Build compiler-tester itself with sanitizer specified with `rust-sanitizer` parameter


More info about Rust sanitizers is available [here](https://rustc-dev-guide.rust-lang.org/sanitizers.html).
Possible values are: `address`, `cfi`, `hwaddress`, `kcfi`, `leak`, `memory`, or `thread`

Only `memory` and `thread` were tested and supported for now, although CI allows us to try other variations.

For more information about the supported sanitizers in LLVM, see [this page](https://www.llvm.org/docs/CMake.html#:~:text=the%20LLVM_SOURCE_PREFIX%20variable.-,LLVM_USE_SANITIZER,-%3ASTRING).

Possible values for LLVM sanitizer are `Address`, `Memory`, `MemoryWithOrigins`, `Undefined`, `Thread`, `DataFlow`, and `Address;Undefined`.

Only `Address` and `Thread` were tested and supported for now, although CI allows us to try other variations.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Fixes [CPR-1052](https://linear.app/matterlabs/issue/CPR-1052/run-compiler-tester-with-address-sanitizer)

# Testing

`Thread` and `Address` sanitizers tested:

* [Address sanitizer workflow](https://github.com/matter-labs/era-compiler-tester/actions/runs/9483006740/job/26129110349) fails with memory leak reported [here](https://linear.app/matterlabs/issue/CPR-1052/run-compiler-tester-with-address-sanitizer#comment-11060950).

* [Thread sanitizer workflow](https://github.com/matter-labs/era-compiler-tester/actions/runs/9546899504/job/26310735820). (Timeout disabled tests execution after ~10 hours, no issues found. I disabled the timeout.)
  * With the Thread Sanitizer tests are running approx. at 100k tests per 2 hours rate.
  * It is suggested to reduce the number of tests or modes using input parameters to get some acceptable execution time.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
