### PR TITLE
feat: remove obsolete warnings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tests"]
 	path = tests
 	url = https://github.com/matter-labs/era-compiler-tests
-	branch = az-cpr-1758-remove-obsolete-solidity-warnings
+	branch = main
 [submodule "solidity"]
 	path = solidity
 	url = https://github.com/ethereum/solidity

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tests"]
 	path = tests
 	url = https://github.com/matter-labs/era-compiler-tests
-	branch = main
+	branch = az-cpr-1758-remove-obsolete-solidity-warnings
 [submodule "solidity"]
 	path = solidity
 	url = https://github.com/ethereum/solidity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.1"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-remove-ascii-boxes#8c3642f769a7a16fb82f0c02c8750cb82706c7b7"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c7ddc4ae653b8dcf048f0016049adadc73d6f848"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.1"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#ace8d5822ac4110949f6c35522f7373952d572cc"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-remove-ascii-boxes#dca86d6ff5c6f55748f203a3e970f105d26d0936"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.1"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-remove-ascii-boxes#dca86d6ff5c6f55748f203a3e970f105d26d0936"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-remove-ascii-boxes#8c3642f769a7a16fb82f0c02c8750cb82706c7b7"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -419,7 +419,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -492,7 +492,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.1"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#2b1058ef8ff0eea037fce839001f87030888cb04"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#ace8d5822ac4110949f6c35522f7373952d572cc"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.1"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#580b4fe5c6a1b589b2af988dc190c7a0af2b8246"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#655f329f0da68ceaa3eeebb9d80c4a826b23d184"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -782,7 +782,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1131,7 +1131,7 @@ source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#bebd00
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1461,7 +1461,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -2118,7 +2118,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2328,9 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2405,7 +2405,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2523,7 +2523,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2674,7 +2674,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "wasm-bindgen-shared",
 ]
 
@@ -2708,7 +2708,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -47,7 +47,7 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-remove-ascii-boxes" }
 era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -47,7 +47,7 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-remove-ascii-boxes" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
 era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }

--- a/compiler_tester/src/compilers/solidity/mod.rs
+++ b/compiler_tester/src/compilers/solidity/mod.rs
@@ -215,7 +215,8 @@ impl SolidityCompiler {
             mode.enable_eravm_extensions,
             false,
             vec![],
-            None,
+            vec![],
+            vec![],
         )
         .map_err(|error| anyhow::anyhow!("Solidity standard JSON I/O error: {}", error))?;
 

--- a/compiler_tester/src/directories/ethereum/test.rs
+++ b/compiler_tester/src/directories/ethereum/test.rs
@@ -227,7 +227,7 @@ impl Buildable for EthereumTest {
                 vec![],
                 debug_config,
             )
-            .map_err(|error| anyhow::anyhow!("Failed to compile sources: {}", error))
+            .map_err(|error| anyhow::anyhow!("Failed to compile sources:\n{error}"))
         {
             Ok(output) => output,
             Err(error) => {
@@ -316,7 +316,7 @@ impl Buildable for EthereumTest {
                 vec![],
                 debug_config,
             )
-            .map_err(|error| anyhow::anyhow!("Failed to compile sources: {}", error))
+            .map_err(|error| anyhow::anyhow!("Failed to compile sources:\n{error}"))
         {
             Ok(output) => output,
             Err(error) => {

--- a/compiler_tester/src/directories/matter_labs/test/mod.rs
+++ b/compiler_tester/src/directories/matter_labs/test/mod.rs
@@ -401,7 +401,7 @@ impl Buildable for MatterLabsTest {
                 vec![],
                 debug_config,
             )
-            .map_err(|error| anyhow::anyhow!("Failed to compile sources: {}", error))
+            .map_err(|error| anyhow::anyhow!("Failed to compile sources:\n{error}"))
         {
             Ok(vm_input) => vm_input,
             Err(error) => {
@@ -527,7 +527,7 @@ impl Buildable for MatterLabsTest {
                 vec![],
                 debug_config,
             )
-            .map_err(|error| anyhow::anyhow!("Failed to compile sources: {}", error))
+            .map_err(|error| anyhow::anyhow!("Failed to compile sources:\n{error}"))
         {
             Ok(output) => output,
             Err(error) => {

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -34,7 +34,7 @@ zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", br
 zkevm_tester = { git = "https://github.com/matter-labs/era-zkevm_tester", branch = "v1.5.0" }
 
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-remove-ascii-boxes" }
 
 compiler-tester = { path = "../compiler_tester" }
 solidity-adapter = { path = "../solidity_adapter" }

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -34,7 +34,7 @@ zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", br
 zkevm_tester = { git = "https://github.com/matter-labs/era-zkevm_tester", branch = "v1.5.0" }
 
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-remove-ascii-boxes" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
 
 compiler-tester = { path = "../compiler_tester" }
 solidity-adapter = { path = "../solidity_adapter" }


### PR DESCRIPTION
# What ❔

1. Removed obsolete warnings for `ecrecover` and `extcodesize`.
2. `send`/`transfer` now trigger an error with ZKsync edition of solc.
3. Added the `suppress-errors` parameter to suppress the error above.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
