### PR TITLE
[WIP] Fix revert strings debug

### DIFF
--- a/compiler_tester/src/compilers/solidity/upstream/solc/standard_json/input/mod.rs
+++ b/compiler_tester/src/compilers/solidity/upstream/solc/standard_json/input/mod.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeSet;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 use serde::Serialize;
+use settings::debug::DebugOpt;
 
 use self::settings::optimizer::Optimizer as SolcStandardJsonInputSettingsOptimizer;
 use self::settings::selection::Selection as SolcStandardJsonInputSettingsSelection;
@@ -65,6 +66,7 @@ impl Input {
                 output_selection,
                 via_ir,
                 optimizer,
+                DebugOpt::new("debug".to_owned())
             ),
         })
     }

--- a/compiler_tester/src/compilers/solidity/upstream/solc/standard_json/input/settings/debug/mod.rs
+++ b/compiler_tester/src/compilers/solidity/upstream/solc/standard_json/input/settings/debug/mod.rs
@@ -1,0 +1,24 @@
+//!
+//! The `solc --standard-json` input settings optimizer.
+//!
+
+use serde::Serialize;
+
+///
+/// The `solc --standard-json` input settings optimizer.
+///
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugOpt {
+    /// Whether the optimizer is enabled.
+    pub revert_strings: String,
+}
+
+impl DebugOpt {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(revert_strings: String) -> Self {
+        Self { revert_strings }
+    }
+}

--- a/compiler_tester/src/compilers/solidity/upstream/solc/standard_json/input/settings/mod.rs
+++ b/compiler_tester/src/compilers/solidity/upstream/solc/standard_json/input/settings/mod.rs
@@ -4,10 +4,12 @@
 
 pub mod optimizer;
 pub mod selection;
+pub mod debug;
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
+use debug::DebugOpt;
 use serde::Serialize;
 
 use self::optimizer::Optimizer;
@@ -40,6 +42,7 @@ pub struct Settings {
     pub via_ir: Option<bool>,
     /// The optimizer settings.
     pub optimizer: Optimizer,
+    pub debug: DebugOpt,
 }
 
 impl Settings {
@@ -53,6 +56,7 @@ impl Settings {
         output_selection: Selection,
         via_ir: bool,
         optimizer: Optimizer,
+        debug: DebugOpt
     ) -> Self {
         Self {
             evm_version,
@@ -61,6 +65,7 @@ impl Settings {
             output_selection: Some(output_selection),
             via_ir: if via_ir { Some(true) } else { None },
             optimizer,
+            debug: debug
         }
     }
 }


### PR DESCRIPTION
# What ❔

A lot of EVM equivalence tests were not working because the debugStrings option was not being passed when compiling with upstream solc using standard json. This PR intends to add that option

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
