### PR TITLE
chore: add linux arm64 platform dir for vyper bins

### DIFF
--- a/configs/vyper-bin-default.json
+++ b/configs/vyper-bin-default.json
@@ -27,6 +27,7 @@
   },
   "platforms": {
     "linux-amd64": "linux",
+    "linux-arm64": "linux",
     "macos-amd64": "darwin",
     "macos-arm64": "darwin"
   }


### PR DESCRIPTION
# What ❔

Add Linux arm64 platform dir for vyper binaries.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To be able to run compiler tester on Linux ARM64 without issues.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
