### PR TITLE
Fix nonce starting at 0

### DIFF
--- a/compiler_tester/src/directories/ethereum/test.rs
+++ b/compiler_tester/src/directories/ethereum/test.rs
@@ -294,7 +294,7 @@ impl Buildable for EthereumTest {
         let last_source = self.last_source(summary.clone(), &mode)?;
 
         let (contract_address, libraries_addresses, libraries) = match self.get_addresses(
-            EVMAddressIterator::new(matches!(target, Target::EVMInterpreter)),
+            EVMAddressIterator::new(false),
             calls.as_slice(),
             last_source.as_str(),
         ) {

--- a/compiler_tester/src/directories/matter_labs/test/mod.rs
+++ b/compiler_tester/src/directories/matter_labs/test/mod.rs
@@ -393,7 +393,7 @@ impl Buildable for MatterLabsTest {
 
         let mut eravm_address_iterator = EraVMAddressIterator::new();
         let evm_address_iterator =
-            EVMAddressIterator::new(matches!(target, Target::EVMInterpreter));
+            EVMAddressIterator::new(false);
 
         let (libraries, library_addresses) = self.get_libraries(&mut eravm_address_iterator);
 
@@ -519,7 +519,7 @@ impl Buildable for MatterLabsTest {
         let sources = self.sources.to_owned();
 
         let mut evm_address_iterator =
-            EVMAddressIterator::new(matches!(target, Target::EVMInterpreter));
+            EVMAddressIterator::new(false);
 
         let (libraries, library_addresses) = self.get_libraries(&mut evm_address_iterator);
 

--- a/compiler_tester/src/test/case/input/output/mod.rs
+++ b/compiler_tester/src/test/case/input/output/mod.rs
@@ -113,10 +113,10 @@ impl Output {
             .iter()
             .map(|value| {
                 let mut value_str = crate::utils::u256_as_string(value);
-                value_str = value_str.replace(
+                /*value_str = value_str.replace(
                     solidity_adapter::DEFAULT_CONTRACT_ADDRESS,
                     &crate::utils::address_as_string(contract_address),
-                );
+                );*/
                 Value::Certain(
                     web3::types::U256::from_str(&value_str)
                         .expect("Solidity adapter default contract address constant is invalid"),


### PR DESCRIPTION
# What ❔

This PR fixes some tests that expected the nonce on EVM to start at 1, while we start it at 0.

This PR depends on https://github.com/lambdaclass/era-contracts/pull/24

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
