### PR TITLE
ci: fix default llvm versions for benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,6 +12,14 @@ on:
         description: "compiler-tester branch to use as a benchmark candidate"
         required: true
         default: "main"
+      compiler_llvm_reference_branch:
+        description: "compiler-llvm branch to use as a benchmark reference"
+        required: false
+        default: "main"
+      compiler_llvm_candidate_branch:
+        description: "compiler-llvm branch to use as a benchmark candidate"
+        required: false
+        default: ""
       compiler_llvm_benchmark_mode:
         description: "Mode filter for compiler-llvm benchmarks"
         required: false
@@ -36,6 +44,8 @@ jobs:
     with:
       compiler_tester_reference_branch: ${{ github.event.inputs.compiler_tester_reference_branch || 'main' }}
       compiler_tester_candidate_branch: ${{ github.event.inputs.compiler_tester_candidate_branch || '' }}
+      compiler_llvm_candidate_branch: ${{ github.event.inputs.compiler_llvm_candidate_branch || '' }}
+      compiler_llvm_reference_branch: ${{ github.event.inputs.compiler_llvm_reference_branch || 'main' }}
       compiler_llvm_benchmark_mode: ${{ github.event.inputs.compiler_llvm_benchmark_mode || '^M^B3' }}
       compiler_llvm_benchmark_path: ${{ github.event.inputs.compiler_llvm_benchmark_path || '' }}
       compiler-tester-repo: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
# What ❔

* [x] Fix for benchmarks case when `LLVM.lock` is changed in compiler-tester branch.
* [x] Add a capability to set LLVM branches when running manually.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Before, by mistake `main` was cloned for LLVM even if LLVM.lock was different.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
