### PR TITLE
fuzzer: fix readme and targets after renaming

### DIFF
--- a/fuzzer/README.md
+++ b/fuzzer/README.md
@@ -26,10 +26,25 @@ path = "fuzz_targets/demo.rs"
 
 ## Running fuzzing
 
-To run the fuzzing, execute the following command:
+### Prerequisites
+
+1. Follow the build instructions from [README.md](../README.md) to build `era-compiler-tester`.
+2. Install the `cargo-fuzz` tool:
+```bash
+cargo install cargo-fuzz
+```
+3. Build `zksolc` compiler and make sure that `zksolc` is added in the `PATH`.
+4. Install nightly Rust toolchain:
+```bash
+rustup toolchain install nightly
+```
+
+### Executing fuzzing
+
+To execute a fuzzing target, run the following command from the root directory of the project:
 
 ```bash
-cargo fuzz run <target_name>
+cargo +nightly fuzz run --fuzz-dir fuzzer <target_name>
 ```
 
 ## Supported targets

--- a/fuzzer/fuzz_targets/common.rs
+++ b/fuzzer/fuzz_targets/common.rs
@@ -151,7 +151,7 @@ pub fn gen_fuzzing_test(case: FuzzingCase) -> anyhow::Result<EthereumTest> {
 /// * `Summary` - The test summary
 pub fn build_and_run(test: EthereumTest) -> anyhow::Result<Summary> {
     // TODO: this should be parametrized
-    let solc_version = semver::Version::new(0, 8, 24);
+    let solc_version = semver::Version::new(0, 8, 26);
     let mode = Mode::Solidity(SolidityMode::new(
         solc_version,
         SolcPipeline::Yul,

--- a/fuzzer/fuzz_targets/demo.rs
+++ b/fuzzer/fuzz_targets/demo.rs
@@ -8,7 +8,7 @@ mod common;
 fuzz_target!(|data: u8| {
     // Fuzzing case definition
     let case = common::FuzzingCase {
-        contract_path: String::from("fuzz/fuzz_contracts/demo/demo.sol"),
+        contract_path: String::from("fuzzer/fuzz_contracts/demo/demo.sol"),
         function_name: String::from("should_always_return_0"),
         input_types: vec![common::TypeVariant::integer_unsigned(8)],
         inputs: vec![common::integer_literal(data)],

--- a/fuzzer/fuzz_targets/optimizer_bug.rs
+++ b/fuzzer/fuzz_targets/optimizer_bug.rs
@@ -7,7 +7,7 @@ mod common;
 fuzz_target!(|data: u8| {
     // Fuzzing case definition
     let case = common::FuzzingCase {
-        contract_path: String::from("fuzz/fuzz_contracts/optimizer_bug/optimizer_bug.sol"),
+        contract_path: String::from("fuzzer/fuzz_contracts/optimizer_bug/optimizer_bug.sol"),
         function_name: String::from("function_to_fuzz"),
         input_types: vec![
             common::TypeVariant::integer_unsigned(8),


### PR DESCRIPTION
# What ❔

Fix readme and targets after renaming `fuzz` to `fuzzer` on the top level.
