### PR TITLE
fix: upstream balance for `ecrecover` address

### DIFF
--- a/compiler_tester/src/vm/eravm/system_context.rs
+++ b/compiler_tester/src/vm/eravm/system_context.rs
@@ -248,7 +248,7 @@ impl SystemContext {
 
             // Fund the 0x01 address with 1 token to match the behavior of upstream Solidity tests.
             let address_ecrecover = crate::utils::address_to_h256(
-                &web3::types::Address::from_low_u64_be(zkevm_opcode_defs::ADDRESS_ETH_TOKEN.into()),
+                &web3::types::Address::from_low_u64_be(zkevm_opcode_defs::ADDRESS_ECRECOVER.into()),
             );
             let bytes = [
                 address_ecrecover.as_bytes(),


### PR DESCRIPTION
# What ❔

After some refactors on the system context storage a wrong address was used instead of the one for the `ecrecover`.

## Why ❔

This change is needed for one of the semanticTest (`solidity/test/libsolidity/semanticTests/various/codebalance_assembly.sol`) to pass.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
