### PR TITLE
fix: burn all gas with assert unreachable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tests"]
 	path = tests
 	url = https://github.com/matter-labs/era-compiler-tests
-	branch = main
+	branch = az-assert-unreachable-burn-gas
 [submodule "solidity"]
 	path = solidity
 	url = https://github.com/ethereum/solidity

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tests"]
 	path = tests
 	url = https://github.com/matter-labs/era-compiler-tests
-	branch = az-assert-unreachable-burn-gas
+	branch = main
 [submodule "solidity"]
 	path = solidity
 	url = https://github.com/ethereum/solidity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.3"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-assert-unreachable-burn-gas#434a4f810fdf0cb0f1dc684e5bd884ce19e266ee"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#072e0713e578505d8eab5a99b5adf1b070c85712"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,8 +574,8 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-vyper"
-version = "1.5.2"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#ceb0fb0f5a5f285b141f6c8ac92b34159913c121"
+version = "1.5.3"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-assert-unreachable-burn-gas#434a4f810fdf0cb0f1dc684e5bd884ce19e266ee"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -48,7 +48,7 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-assert-unreachable-burn-gas" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }
 # era-compiler-llvm-context = { path = "../../era-compiler-llvm-context" }

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -48,7 +48,7 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-assert-unreachable-burn-gas" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }
 # era-compiler-llvm-context = { path = "../../era-compiler-llvm-context" }


### PR DESCRIPTION
# What ❔

Burn all gas with assert unreachable.

Fixes https://github.com/matter-labs/era-compiler-vyper/issues/83

## Why ❔

It has been translated to the equivalent of `REVERT` instead of `INVALID`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
