### PR TITLE
feat: vyper combined JSON I/O overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.3"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#072e0713e578505d8eab5a99b5adf1b070c85712"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-remove-combined-json-call#b18c7dae957bbf7af2ed697329c5ccf528dee466"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.3"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-remove-combined-json-call#b18c7dae957bbf7af2ed697329c5ccf528dee466"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#fd5ff9401cd9cf665d500209fbd30cd3c245c5e4"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -48,7 +48,7 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-remove-combined-json-call" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }
 # era-compiler-llvm-context = { path = "../../era-compiler-llvm-context" }

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -48,7 +48,7 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-remove-combined-json-call" }
 
 # era-compiler-common = { path = "../../era-compiler-common" }
 # era-compiler-llvm-context = { path = "../../era-compiler-llvm-context" }

--- a/compiler_tester/src/vm/eravm/mod.rs
+++ b/compiler_tester/src/vm/eravm/mod.rs
@@ -132,12 +132,12 @@ impl EraVM {
         );
         vm.add_known_contract(
             zkevm_assembly::Assembly::from_string(
-                era_compiler_vyper::FORWARDER_CONTRACT_ASSEMBLY.to_owned(),
+                era_compiler_vyper::MINIMAL_PROXY_CONTRACT_ASSEMBLY.to_owned(),
                 None,
             )
             .expect("Always valid"),
             web3::types::U256::from_str_radix(
-                era_compiler_vyper::FORWARDER_CONTRACT_HASH.as_str(),
+                era_compiler_vyper::MINIMAL_PROXY_CONTRACT_HASH.as_str(),
                 era_compiler_common::BASE_HEXADECIMAL,
             )
             .expect("Always valid"),


### PR DESCRIPTION
# What ❔

Removes all calls to `vyper` except `batch`. Now all data will be requested with a single call to `batch`, as it is the most universal endpoint of the underlying `vyper` compiler. 

## Why ❔

At the moment (v0.4.0) it is extremely slow and single-threaded. It takes eternity to run on MacOS arm64, probably due to compatibility reasons.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
