### PR TITLE
`clippy --fix`s

### DIFF
--- a/compiler_tester/src/test/case/input/output/event.rs
+++ b/compiler_tester/src/test/case/input/output/event.rs
@@ -166,7 +166,7 @@ impl From<zkevm_tester::events::SolidityLikeEvent> for Event {
 
 impl From<evm::Log> for Event {
     fn from(log: evm::Log) -> Self {
-        let address = log.address;
+        let _address = log.address;
         let topics = log
             .topics
             .into_iter()

--- a/compiler_tester/src/vm/eravm/mod.rs
+++ b/compiler_tester/src/vm/eravm/mod.rs
@@ -265,7 +265,7 @@ impl EraVM {
             }
 
             for (hash, preimage) in snapshot.published_sha256_blobs.iter() {
-                if self.published_evm_bytecodes.contains_key(&hash) {
+                if self.published_evm_bytecodes.contains_key(hash) {
                     continue;
                 }
 

--- a/compiler_tester/src/vm/evm/mod.rs
+++ b/compiler_tester/src/vm/evm/mod.rs
@@ -79,7 +79,7 @@ impl<'evm> EVM<'evm> {
     ///
     pub fn execute_deploy_code(
         &mut self,
-        test_name: String,
+        _test_name: String,
         path: &str,
         caller: web3::types::Address,
         value: Option<u128>,
@@ -122,7 +122,7 @@ impl<'evm> EVM<'evm> {
             Ok(evm::standard::TransactValue::Call { .. }) => {
                 unreachable!("The `Create` transaction must be executed above")
             }
-            Err(error) => (web3::types::Address::zero(), true),
+            Err(_error) => (web3::types::Address::zero(), true),
         };
 
         let mut return_data = vec![
@@ -143,7 +143,7 @@ impl<'evm> EVM<'evm> {
     ///
     pub fn execute_runtime_code(
         &mut self,
-        test_name: String,
+        _test_name: String,
         address: web3::types::Address,
         caller: web3::types::Address,
         value: Option<u128>,
@@ -181,7 +181,7 @@ impl<'evm> EVM<'evm> {
             Ok(evm::standard::TransactValue::Create { .. }) => {
                 unreachable!("The `Call` transaction must be executed above")
             }
-            Err(error) => (vec![], true),
+            Err(_error) => (vec![], true),
         };
 
         let events = self.runtime.logs.drain(..).collect();

--- a/compiler_tester/src/vm/evm/runtime.rs
+++ b/compiler_tester/src/vm/evm/runtime.rs
@@ -43,7 +43,7 @@ impl Runtime {
 }
 
 impl evm::RuntimeEnvironment for Runtime {
-    fn block_hash(&self, number: web3::types::U256) -> web3::types::H256 {
+    fn block_hash(&self, _number: web3::types::U256) -> web3::types::H256 {
         crate::utils::u256_to_h256(
             &web3::types::U256::from_str_radix(
                 "3737373737373737373737373737373737373737373737373737373737373862",
@@ -108,7 +108,7 @@ impl evm::RuntimeBaseBackend for Runtime {
             .unwrap_or(web3::types::U256::zero())
     }
 
-    fn code_hash(&self, address: web3::types::H160) -> web3::types::H256 {
+    fn code_hash(&self, _address: web3::types::H160) -> web3::types::H256 {
         web3::types::H256::zero()
     }
 
@@ -142,11 +142,11 @@ impl evm::RuntimeBackend for Runtime {
         evm::RuntimeBaseBackend::storage(self, address, index)
     }
 
-    fn deleted(&self, address: web3::types::H160) -> bool {
+    fn deleted(&self, _address: web3::types::H160) -> bool {
         false
     }
 
-    fn is_cold(&self, address: web3::types::H160, index: Option<web3::types::H256>) -> bool {
+    fn is_cold(&self, _address: web3::types::H160, _index: Option<web3::types::H256>) -> bool {
         false
     }
 
@@ -154,7 +154,7 @@ impl evm::RuntimeBackend for Runtime {
         !self.is_cold(address, index)
     }
 
-    fn mark_hot(&mut self, address: web3::types::H160, index: Option<web3::types::H256>) {}
+    fn mark_hot(&mut self, _address: web3::types::H160, _index: Option<web3::types::H256>) {}
 
     fn set_storage(
         &mut self,
@@ -180,9 +180,9 @@ impl evm::RuntimeBackend for Runtime {
         Ok(())
     }
 
-    fn mark_delete(&mut self, address: web3::types::H160) {}
+    fn mark_delete(&mut self, _address: web3::types::H160) {}
 
-    fn reset_storage(&mut self, address: web3::types::H160) {}
+    fn reset_storage(&mut self, _address: web3::types::H160) {}
 
     fn set_code(
         &mut self,
@@ -238,5 +238,5 @@ impl evm::RuntimeBackend for Runtime {
 impl evm::TransactionalBackend for Runtime {
     fn push_substate(&mut self) {}
 
-    fn pop_substate(&mut self, strategy: evm::MergeStrategy) {}
+    fn pop_substate(&mut self, _strategy: evm::MergeStrategy) {}
 }

--- a/solidity_adapter/src/test/function_call/parser/lexical/stream/integer/mod.rs
+++ b/solidity_adapter/src/test/function_call/parser/lexical/stream/integer/mod.rs
@@ -34,10 +34,10 @@ pub enum State {
 /// Integer literals can be of two types:
 ///
 /// 1. Decimal
-/// '-42'
+///    '-42'
 ///
 /// 2. Hexadecimal
-/// '2a'
+///    '2a'
 ///
 pub fn parse(input: &str) -> Result<Output, Error> {
     let mut state = State::Start;

--- a/solidity_adapter/src/test/function_call/parser/lexical/stream/word/mod.rs
+++ b/solidity_adapter/src/test/function_call/parser/lexical/stream/word/mod.rs
@@ -31,16 +31,16 @@ pub enum State {
 /// Parses a word. The word can result into several token types:
 ///
 /// 1. An identifier
-/// 'value'
-/// Any valid identifier which is not a keyword.
+///    'value'
+///    Any valid identifier which is not a keyword.
 ///
 /// 2. A boolean literal
-/// 'true'
-/// The literal is also a keyword, but is was decided to treat literals as a separate token type.
+///    'true'
+///    The literal is also a keyword, but is was decided to treat literals as a separate token type.
 ///
 /// 3. A keyword
-/// 'emit'
-/// Any keyword which is not a boolean literal.
+///    'emit'
+///    Any keyword which is not a boolean literal.
 ///
 pub fn parse(input: &str) -> Output {
     let mut state = State::Start;


### PR DESCRIPTION
# What ❔
Clippy auto-fixes for some (not all) warnings which were annoying me as I learn Rust, via
```
__CARGO_FIX_YOLO=1  cargo clippy --fix --allow-dirty  -- -Dwarnings
```

## Checklist

- [x] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
