### PR TITLE
ci: support custom LLVM branch in sanitizers

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -3,6 +3,11 @@ name: Sanitizers tests
 on:
   workflow_dispatch:
     inputs:
+      llvm-branch:
+        description: 'Custom LLVM branch to use. If not specified, the branch from `LLVM.lock` file is used.'
+        required: false
+        default: ''
+        type: string
       # For more information about the supported sanitizers in Rust, see:
       # https://rustc-dev-guide.rust-lang.org/sanitizers.html
       rust-sanitizer:
@@ -44,9 +49,18 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Checkout llvm
+        if: inputs.llvm-branch != ''
+        uses: actions/checkout@v4
+        with:
+          repository: matter-labs/era-compiler-llvm
+          ref: ${{ inputs.llvm-branch }}
+          path: llvm
+
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
+          clone-llvm: ${{ inputs.llvm-branch == '' }}
           sanitizer: ${{ inputs.llvm-sanitizer }}
           enable-assertions: true
 


### PR DESCRIPTION
# What ❔

Add the capability to choose the LLVM branch when running with sanitizers.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To allow testing different LLVM branches without the need to create a branch and update `LLVM.lock` manually.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Test

Tested manually through actions:
1. [Run with a custom branch](https://github.com/matter-labs/era-compiler-tester/actions/runs/10522529132/job/29155353431)
2. [Run with a default '' empty value](https://github.com/matter-labs/era-compiler-tester/actions/runs/10522603413)

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
