### PR TITLE
feat: Prepopulate tstorage for the new version of EvmGasManager

### DIFF
--- a/compiler_tester/src/vm/eravm/mod.rs
+++ b/compiler_tester/src/vm/eravm/mod.rs
@@ -398,6 +398,7 @@ impl EraVM {
         calldata: Vec<u8>,
         vm_launch_option: Option<zkevm_tester::compiler_tests::VmLaunchOption>,
     ) -> anyhow::Result<ExecutionResult> {
+        // legacy EvmGasManager.sol compatibility
         // set `evmStackFrames` size to 1
         self.storage.insert(
             zkevm_tester::compiler_tests::StorageKey {
@@ -423,6 +424,34 @@ impl EraVM {
                 key: web3::types::U256::from(Self::EVM_GAS_MANAGER_FIRST_STACK_FRAME).add(1),
             },
             web3::types::H256::from_low_u64_be(Self::EVM_CALL_GAS_LIMIT),
+        );
+
+        // updated EvmGasManager.sol compatibility
+        // set `evmStackFrames` size to 1
+        self.storage_transient.insert(
+            zkevm_tester::compiler_tests::StorageKey {
+                address: web3::types::Address::from_low_u64_be(ADDRESS_EVM_GAS_MANAGER.into()),
+                key: web3::types::U256::from(Self::EVM_GAS_MANAGER_STACK_FRAME_SLOT),
+            },
+            web3::types::H256::from_low_u64_be(1),
+        );
+
+        // set `evmStackFrames[0].passGas` to `EVM_CALL_GAS_LIMIT`
+        self.storage_transient.insert(
+            zkevm_tester::compiler_tests::StorageKey {
+                address: web3::types::Address::from_low_u64_be(ADDRESS_EVM_GAS_MANAGER.into()),
+                key: web3::types::U256::from(Self::EVM_GAS_MANAGER_STACK_FRAME_SLOT).add(2),
+            },
+            web3::types::H256::from_low_u64_be(Self::EVM_CALL_GAS_LIMIT),
+        );
+
+        // set `evmStackFrames[0].isStatic` to false
+        self.storage_transient.insert(
+            zkevm_tester::compiler_tests::StorageKey {
+                address: web3::types::Address::from_low_u64_be(ADDRESS_EVM_GAS_MANAGER.into()),
+                key: web3::types::U256::from(Self::EVM_GAS_MANAGER_STACK_FRAME_SLOT).add(3),
+            },
+            web3::types::H256::zero(),
         );
 
         let mut result = self.execute::<M>(


### PR DESCRIPTION
# What ❔

Required for https://github.com/matter-labs/era-contracts/pull/738

The logic of prepopulating **storage** is left for compatibility with the previous version of the contract

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
