### PR TITLE
ci: add mandatory target parameter to sanitizers workflow

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -32,6 +32,11 @@ on:
         type: string
         default: 'Y+M3B3 0.8.26'
         description: 'Mode filter for the era-compiler-tester. For example: Y+M3B3 0.8.26'
+      target:
+        required: false
+        type: string
+        default: 'eravm'
+        description: 'Target filter for the era-compiler-tester. Possible values are: `eravm` or `evm`'
 
 jobs:
   run-with-sanitizers:
@@ -88,6 +93,7 @@ jobs:
         run: |
           set -x
           ./target/${TARGET}/debug/compiler-tester \
+            --target "${{ inputs.target }}" \
             --zksolc "./target-zksolc/${TARGET}/debug/zksolc" \
             --zkvyper "./target-zkvyper/${TARGET}/debug/zkvyper" \
             --path '${{ inputs.path }}' \


### PR DESCRIPTION
# What ❔

Introduce `--target` parameter in the sanitizer workflow.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

`--target` parameter is mandatory now. 

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
