### PR TITLE
ci: fix sanitizers mode to 0.8.27 after solc update

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -30,8 +30,8 @@ on:
       mode:
         required: false
         type: string
-        default: 'Y+M3B3 0.8.26'
-        description: 'Mode filter for the era-compiler-tester. For example: Y+M3B3 0.8.26'
+        default: 'Y+M3B3 0.8.27'
+        description: 'Mode filter for the era-compiler-tester. For example: Y+M3B3 0.8.27'
       target:
         required: false
         type: string


### PR DESCRIPTION
# What ❔

Fix sanitizers mode to 0.8.27 after solc update.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
