### PR TITLE
feat: exclusive dependency resolution by the linker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fce5dbd6a4f118eecc4719eaa9c7ffc31c315e6c5ccde3642db927802312425"
+checksum = "3aeeb5825c2fc8c2662167058347cd0cafc3cb15bcb5cdb1758a63c2dca0409e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -1028,7 +1028,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#32637b83bf23b7b177c7d711992a6f6f101ac399"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#88c658dbd40a1611a31b991c7f427cb33cc97139"
 dependencies = [
  "anyhow",
  "base58",
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-downloader"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#32637b83bf23b7b177c7d711992a6f6f101ac399"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#88c658dbd40a1611a31b991c7f427cb33cc97139"
 dependencies = [
  "anyhow",
  "colored",
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#5f88ca511f972dae2d67fb91598b9f9b434c1731"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-link-factory-dependencies#8559d9a2d133638ebb15c5b129f29c6b26a7782c"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c5f34a12f2b991bb0d08ffdadd3b7c56f4ed5548"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-link-factory-dependencies#fa60c042d689fbc91023df3fa2e623a47f41f598"
 dependencies = [
  "anyhow",
  "clap",
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#59a41bb41fb76a0cc04679c772406258323ec780"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-link-factory-dependencies#866f8fb5822c4faed235b941f7a53f1509663892"
 dependencies = [
  "anyhow",
  "clap",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "era-solc"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c5f34a12f2b991bb0d08ffdadd3b7c56f4ed5548"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-link-factory-dependencies#fa60c042d689fbc91023df3fa2e623a47f41f598"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "era-yul"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c5f34a12f2b991bb0d08ffdadd3b7c56f4ed5548"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-link-factory-dependencies#fa60c042d689fbc91023df3fa2e623a47f41f598"
 dependencies = [
  "anyhow",
  "regex",
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "headers"
@@ -1838,13 +1838,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#2b02c986508b68a38f9eb0f46919d5d1a1b0bfc1"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=az-link-factory-dependencies#2026c61a299e3b155b4fa178da720102faed69ca"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1859,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#2b02c986508b68a38f9eb0f46919d5d1a1b0bfc1"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=az-link-factory-dependencies#2026c61a299e3b155b4fa178da720102faed69ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
@@ -1993,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
 
 [[package]]
 name = "libm"
@@ -2032,14 +2032,14 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "llvm-sys"
 version = "170.0.1"
-source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=llvm-17.0#b06c3d1989fa5d77e491e6aea709dd5c76621aff"
+source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=az-link-factory-dependencies#06e688f7aca46125bebce1bedc881e3a127ab65e"
 dependencies = [
  "anyhow",
  "cc",
@@ -3692,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -3788,9 +3788,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna 1.0.3",
@@ -4194,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4206,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4239,18 +4239,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -48,10 +48,10 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true, package = "
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-link-factory-dependencies" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-link-factory-dependencies" }
+era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-link-factory-dependencies" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-link-factory-dependencies" }
 
 solidity-adapter = { path = "../solidity_adapter" }
 benchmark-analyzer = { path = "../benchmark_analyzer" }
@@ -68,6 +68,6 @@ features = ["blocking"]
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"
-branch = "llvm-17"
+branch = "az-link-factory-dependencies"
 default-features = false
 features = ["llvm17-0", "no-libffi-linking", "target-eravm", "target-evm"]

--- a/compiler_tester/src/compilers/eravm/mod.rs
+++ b/compiler_tester/src/compilers/eravm/mod.rs
@@ -49,17 +49,17 @@ impl Compiler for EraVMCompiler {
         let build = project.compile_to_eravm(
             &mut vec![],
             true,
-            BTreeMap::new(),
             era_compiler_common::HashType::Ipfs,
             era_compiler_llvm_context::OptimizerSettings::none(),
             llvm_options,
             true,
-            None,
             debug_config.clone(),
         )?;
         build.collect_errors()?;
+        let build = build.link(BTreeMap::new())?;
+        build.collect_errors()?;
         let builds = build
-            .contracts
+            .results
             .into_iter()
             .map(|(path, result)| Ok((path, result.expect("Always valid").build)))
             .collect::<anyhow::Result<HashMap<String, era_compiler_llvm_context::EraVMBuild>>>()?;

--- a/compiler_tester/src/compilers/llvm/mod.rs
+++ b/compiler_tester/src/compilers/llvm/mod.rs
@@ -66,17 +66,17 @@ impl Compiler for LLVMCompiler {
         let build = project.compile_to_eravm(
             &mut vec![],
             true,
-            linker_symbols,
             era_compiler_common::HashType::Ipfs,
             mode.llvm_optimizer_settings.to_owned(),
             llvm_options,
             true,
-            None,
             debug_config.clone(),
         )?;
         build.collect_errors()?;
+        let build = build.link(linker_symbols)?;
+        build.collect_errors()?;
         let builds = build
-            .contracts
+            .results
             .into_iter()
             .map(|(path, result)| Ok((path, result.expect("Always valid").build)))
             .collect::<anyhow::Result<HashMap<String, era_compiler_llvm_context::EraVMBuild>>>()?;

--- a/compiler_tester/src/compilers/solidity/mod.rs
+++ b/compiler_tester/src/compilers/solidity/mod.rs
@@ -361,23 +361,23 @@ impl Compiler for SolidityCompiler {
         let build = project.compile_to_eravm(
             &mut vec![],
             mode.enable_eravm_extensions,
-            linker_symbols,
             era_compiler_common::HashType::Ipfs,
             mode.llvm_optimizer_settings.to_owned(),
             llvm_options,
             true,
-            None,
             debug_config,
         )?;
         build.collect_errors()?;
+        let build = build.link(linker_symbols)?;
+        build.collect_errors()?;
         let builds = build
-            .contracts
+            .results
             .iter()
             .map(|(path, build)| {
                 let build = build.to_owned().expect("Always valid");
-                let build = era_compiler_llvm_context::EraVMBuild::new(
+                let build = era_compiler_llvm_context::EraVMBuild::new_with_bytecode_hash(
                     build.build.bytecode,
-                    build.build.bytecode_hash,
+                    build.build.bytecode_hash.expect("Always valid"),
                     None,
                     build.build.assembly,
                 );

--- a/compiler_tester/src/compilers/solidity/upstream/mod.rs
+++ b/compiler_tester/src/compilers/solidity/upstream/mod.rs
@@ -498,9 +498,9 @@ impl Compiler for SolidityCompiler {
                 .map_err(|_| {
                     anyhow::anyhow!("EraVM bytecode of the contract `{path}` hashing error")
                 })?;
-                let build = era_compiler_llvm_context::EraVMBuild::new(
+                let build = era_compiler_llvm_context::EraVMBuild::new_with_bytecode_hash(
                     bytecode,
-                    Some(bytecode_hash),
+                    bytecode_hash,
                     None,
                     None,
                 );

--- a/compiler_tester/src/compilers/vyper/mod.rs
+++ b/compiler_tester/src/compilers/vyper/mod.rs
@@ -237,9 +237,9 @@ impl Compiler for VyperCompiler {
             .contracts
             .into_iter()
             .map(|(path, contract)| {
-                let build = era_compiler_llvm_context::EraVMBuild::new(
+                let build = era_compiler_llvm_context::EraVMBuild::new_with_bytecode_hash(
                     contract.build.bytecode,
-                    contract.build.bytecode_hash,
+                    contract.build.bytecode_hash.expect("Always exists"),
                     None,
                     contract.build.assembly,
                 );

--- a/compiler_tester/src/compilers/yul/mod.rs
+++ b/compiler_tester/src/compilers/yul/mod.rs
@@ -96,23 +96,23 @@ impl Compiler for YulCompiler {
         let build = project.compile_to_eravm(
             &mut vec![],
             mode.enable_eravm_extensions,
-            linker_symbols,
             era_compiler_common::HashType::Ipfs,
             mode.llvm_optimizer_settings.to_owned(),
             llvm_options,
             true,
-            None,
             debug_config.clone(),
         )?;
         build.collect_errors()?;
+        let build = build.link(linker_symbols)?;
+        build.collect_errors()?;
         let builds = build
-            .contracts
+            .results
             .into_iter()
             .map(|(path, result)| {
                 let contract = result.expect("Always valid");
-                let build = era_compiler_llvm_context::EraVMBuild::new(
+                let build = era_compiler_llvm_context::EraVMBuild::new_with_bytecode_hash(
                     contract.build.bytecode,
-                    contract.build.bytecode_hash,
+                    contract.build.bytecode_hash.expect("Always exists"),
                     None,
                     contract.build.assembly,
                 );

--- a/compiler_tester/src/vm/eravm/mod.rs
+++ b/compiler_tester/src/vm/eravm/mod.rs
@@ -169,9 +169,9 @@ impl EraVM {
             ),
         );
         vm.add_known_contract(
-            era_compiler_vyper::MINIMAL_PROXY_CONTRACT_BYTECODE.to_owned(),
+            era_compiler_vyper::MINIMAL_PROXY_CONTRACT.0.to_owned(),
             web3::types::U256::from_big_endian(
-                era_compiler_vyper::MINIMAL_PROXY_CONTRACT_HASH.as_slice(),
+                era_compiler_vyper::MINIMAL_PROXY_CONTRACT.1.as_slice(),
             ),
         );
 


### PR DESCRIPTION
# What ❔

All libraries and factory dependencies are now linked by the LLVM linker only.

## Why ❔

It greatly simplifies the FE and gives a compilation speed boost.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
