### PR TITLE
fix(evm): supports EVMLA PUSHSIZE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c0cb2c6764f8ecbf209f75e518a4261375fb5eed"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-support-evmla-pushsize#2b0da9ed28045642125af15f3d69d5dce8b070dc"
 dependencies = [
  "anyhow",
  "clap",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "era-solc"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c0cb2c6764f8ecbf209f75e518a4261375fb5eed"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-support-evmla-pushsize#2b0da9ed28045642125af15f3d69d5dce8b070dc"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "era-yul"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c0cb2c6764f8ecbf209f75e518a4261375fb5eed"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-support-evmla-pushsize#2b0da9ed28045642125af15f3d69d5dce8b070dc"
 dependencies = [
  "anyhow",
  "regex",

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -49,8 +49,8 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true, package = "
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-support-evmla-pushsize" }
+era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-support-evmla-pushsize" }
 era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 
 solidity-adapter = { path = "../solidity_adapter" }


### PR DESCRIPTION
The support for it was missing, leading to failures or constructors with args, including ERC20.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
