### PR TITLE
fix: remove the branch replacing call(0x04) with memcopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#050e09791561286b1faf116eb5ee4cd6a010dd9a"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-identity-precompile-no-memcopy#3068d634773ec2074b9baf98be694d45782a17dc"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#cad69d46f008e96909282921ce79fca6d2fe9b5a"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-identity-precompile-no-memcopy#34093762e4f2856ae6b8bede0844e5dbff0977b2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#1bf4baeafcacf72f9e11adae106c6c6b6339df51"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=az-identity-precompile-no-memcopy#1369f180ada4114a522b65221b56be9ced4006c9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "era-solc"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#cad69d46f008e96909282921ce79fca6d2fe9b5a"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-identity-precompile-no-memcopy#34093762e4f2856ae6b8bede0844e5dbff0977b2"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "era-yul"
 version = "1.5.8"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#cad69d46f008e96909282921ce79fca6d2fe9b5a"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=az-identity-precompile-no-memcopy#34093762e4f2856ae6b8bede0844e5dbff0977b2"
 dependencies = [
  "anyhow",
  "regex",

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -48,10 +48,10 @@ vm2 = { git = "https://github.com/matter-labs/vm2", optional = true, package = "
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
-era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-identity-precompile-no-memcopy" }
+era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-identity-precompile-no-memcopy" }
+era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "az-identity-precompile-no-memcopy" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "az-identity-precompile-no-memcopy" }
 
 solidity-adapter = { path = "../solidity_adapter" }
 benchmark-analyzer = { path = "../benchmark_analyzer" }


### PR DESCRIPTION
Removes the branch replacing call(0x04) with memcopy.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
