### PR TITLE
Fix mode filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ Most of the specifiers support wildcards `*` (any), `^` ('3' and 'z').
 With no mode argument, iterates over all option combinations (approximately 800).
 
 
-
 ## Usage
 
 Each command assumes you are at the root of the `compiler-tester` repository.
@@ -227,6 +226,8 @@ cargo run --release --bin compiler-tester -- -DT \
 	--mode='Y+M3B3 0.8.26' \
 	--zksolc '../era-compiler-solidity/target/release/zksolc'
 ```
+
+Modes are insensitive to spaces, therefore options such as `'Y+M3B3 0.8.26'` and `'Y +  M3B3     0.8.26'` are equivalent.
 
 ### Example 2
 

--- a/compiler_tester/src/compilers/mode/imode.rs
+++ b/compiler_tester/src/compilers/mode/imode.rs
@@ -17,13 +17,13 @@ pub trait IMode {
 }
 
 pub fn mode_to_string_aux(mode: &impl IMode, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    for (i, element) in [mode.optimizations(), mode.codegen(), mode.version()]
+    for (i, element) in [mode.codegen(), mode.optimizations(), mode.version()]
         .iter()
         .flatten()
         .enumerate()
     {
         if i > 0 {
-            write!(f, "  ")?;
+            write!(f, " ")?;
         }
         write!(f, "{}", element)?;
     }

--- a/compiler_tester/src/compilers/mode/mod.rs
+++ b/compiler_tester/src/compilers/mode/mod.rs
@@ -211,6 +211,7 @@ impl Mode {
             }
         }
 
+        current = current.replace(' ',"");
         current
     }
 }

--- a/compiler_tester/src/compilers/mode/mod.rs
+++ b/compiler_tester/src/compilers/mode/mod.rs
@@ -211,7 +211,7 @@ impl Mode {
             }
         }
 
-        current = current.replace(' ',"");
+        current = current.replace(' ', "");
         current
     }
 }

--- a/compiler_tester/src/filters.rs
+++ b/compiler_tester/src/filters.rs
@@ -32,7 +32,10 @@ impl Filters {
             path_filters: path_filters.into_iter().collect(),
             // Mode filters are stripped of spaces so filters like "Y+M3B3
             // 0.2.1 " and "Y +M3B3 0.2.1" become equivalent
-            mode_filters: mode_filters.into_iter().map(|f| f.replace(' ', "")).collect(),
+            mode_filters: mode_filters
+                .into_iter()
+                .map(|f| f.replace(' ', ""))
+                .collect(),
             group_filters: group_filters.into_iter().collect(),
         }
     }

--- a/compiler_tester/src/filters.rs
+++ b/compiler_tester/src/filters.rs
@@ -30,7 +30,9 @@ impl Filters {
     ) -> Self {
         Self {
             path_filters: path_filters.into_iter().collect(),
-            mode_filters: mode_filters.into_iter().collect(),
+            // Mode filters are stripped of spaces so filters like "Y+M3B3
+            // 0.2.1 " and "Y +M3B3 0.2.1" become equivalent
+            mode_filters: mode_filters.into_iter().map(|f| f.replace(' ', "")).collect(),
             group_filters: group_filters.into_iter().collect(),
         }
     }


### PR DESCRIPTION
# What ❔

After the massive refactoring mode filters were broken.
Now not only they are repaired (so that they work as they did previously) but they are space-insensitive.
Mode filters such `Y+M3B3` and `Y +  M3 B3     0.1.2` are now equivalent.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
