### PR TITLE
feat: Add support for vyper 0.4.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tests"]
     path = tests
-    url = https://github.com/matter-labs/era-compiler-tests
-    branch = main
+    url = https://github.com/s3bc40/era-compiler-tests
+    branch = feat/vyper-0-4-1-changes
 [submodule "solidity"]
     path = solidity
     url = https://github.com/ethereum/solidity

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tests"]
     path = tests
-    url = https://github.com/s3bc40/era-compiler-tests
-    branch = feat/vyper-0-4-1-changes
+    url = https://github.com/matter-labs/era-compiler-tests
+    branch = main
 [submodule "solidity"]
     path = solidity
     url = https://github.com/ethereum/solidity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.10"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#1935a0bc56ab905c59cdc0bf5c2eaa77098477fe"
+source = "git+https://github.com/s3bc40/era-compiler-vyper?branch=feat%2Fadd-support-vyper-0-4-1#73eb55bcb5add030f9e99f0815cc1190a236753f"
 dependencies = [
  "anyhow",
  "boolinator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.10"
-source = "git+https://github.com/s3bc40/era-compiler-vyper?branch=feat%2Fadd-support-vyper-0-4-1#73eb55bcb5add030f9e99f0815cc1190a236753f"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#f0d4a3b028f7028fa0b68e72f9a523b25bd16f62"
 dependencies = [
  "anyhow",
  "boolinator",

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -51,7 +51,7 @@ era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-c
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
 era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
+era-compiler-vyper = { git = "https://github.com/s3bc40/era-compiler-vyper", branch = "feat/add-support-vyper-0-4-1" }
 
 solidity-adapter = { path = "../solidity_adapter" }
 benchmark-analyzer = { path = "../benchmark_analyzer" }

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -51,7 +51,7 @@ era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-c
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
 era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
-era-compiler-vyper = { git = "https://github.com/s3bc40/era-compiler-vyper", branch = "feat/add-support-vyper-0-4-1" }
+era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 
 solidity-adapter = { path = "../solidity_adapter" }
 benchmark-analyzer = { path = "../benchmark_analyzer" }

--- a/configs/vyper-bin-default.json
+++ b/configs/vyper-bin-default.json
@@ -23,6 +23,12 @@
       "protocol": "https",
       "source": "https://github.com/vyperlang/vyper/releases/download/v${VERSION}/vyper.${VERSION}+commit.e9db8d9f.${PLATFORM}",
       "destination": "./vyper-bin/vyper-${VERSION}"
+    },
+    "0.4.1": {
+      "is_enabled": true,
+      "protocol": "https",
+      "source": "https://github.com/vyperlang/vyper/releases/download/v${VERSION}/vyper.${VERSION}+commit.8a93dd27.${PLATFORM}",
+      "destination": "./vyper-bin/vyper-${VERSION}"
     }
   },
   "platforms": {


### PR DESCRIPTION
# What ❔

- Add vyper bin default config for vyper 0.4.1

Tests are all running. But there are warnings for deprecated functions `>= 0.4.0`:
- `shift` -> use `<<` or `>>`
- `log`: `Deprecation: Instantiating events with positional arguments is deprecated as of v0.4.1 and will be disallowed in a future release. Use kwargs instead`

*Related issue:* https://github.com/matter-labs/era-compiler-vyper/issues/156
*Related PR for `era-compiler-vyper`:* https://github.com/matter-labs/era-compiler-vyper/pull/157

Needed branch to test in `compiler_tester/Cargo.toml`:
```toml
era-compiler-vyper = { git = "https://github.com/s3bc40/era-compiler-vyper", branch = "feat/add-support-vyper-0-4-1" }
```

## Why ❔

To allow `era-compiler-tester` to run with `vyper==0.4.1`. 

Previous tests are already adapted with `#! { "modes": [ "V >=0.4.0" ]`. To prevent future deprecation, it might be the best to go to all files to adapt as much as we can.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

---

## Todo
- [x] check for `log` and adapt to `kwarg` syntax
```diff
- log CollateralRedeemed(token_collateral_address, amount, _from, _to)
+ log CollateralRedeemed(token=token_collateral_address, amount=amount, _from=_from, _to=_to)
```
- [x] check for `shift` and try to adapt to  `<<` or `>>`
> A positive _shift value equals a left shift, a negative value is a right shift.
