### PR TITLE
chore: update deps after everything has been made submodules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#aa3667e7f0f9af5044b2b977fce1f33bc32901c6"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#d73546135703b8d9dfd26d4f7bc4e7539b910157"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1149,8 +1149,8 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-solidity"
-version = "1.5.13"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#0150aef2bd6f7775440a5d0ca62dc813c17dc7c0"
+version = "1.5.14"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c3041ceb37f7164c21ed8dabb57c6bb986c79b3b"
 dependencies = [
  "anyhow",
  "clap",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.10"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#27df1d55444fe6d3d4c792a4b1f0d37ac72b0ba1"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#6be39756cf441c12737df8aac6b21225e230841c"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -1196,8 +1196,8 @@ dependencies = [
 
 [[package]]
 name = "era-solc"
-version = "1.5.13"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#0150aef2bd6f7775440a5d0ca62dc813c17dc7c0"
+version = "1.5.14"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c3041ceb37f7164c21ed8dabb57c6bb986c79b3b"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -1213,8 +1213,8 @@ dependencies = [
 
 [[package]]
 name = "era-yul"
-version = "1.5.13"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#0150aef2bd6f7775440a5d0ca62dc813c17dc7c0"
+version = "1.5.14"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#c3041ceb37f7164c21ed8dabb57c6bb986c79b3b"
 dependencies = [
  "anyhow",
  "regex",
@@ -3124,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
  "ring",


### PR DESCRIPTION
Updates deps after solx's and other FEs' deps have been made submodules.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
