### PR TITLE
chore: support llvm as a git submodule

### DIFF
--- a/.github/workflows/ccache-regen.yml
+++ b/.github/workflows/ccache-regen.yml
@@ -43,6 +43,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Checkout submodules
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --force --depth=1 --recursive --checkout
 
       - name: Build LLVM for tests
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
@@ -51,7 +58,7 @@ jobs:
           build-type: RelWithDebInfo
           save-ccache: 'false'
           enable-assertions: 'true'
-          clone-llvm: 'true'
+          clone-llvm: 'false'
           ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, 'gnu') }}
 
       - name: Build LLVM for benchmarks

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -3,11 +3,6 @@ name: Sanitizers tests
 on:
   workflow_dispatch:
     inputs:
-      llvm-branch:
-        description: 'Custom LLVM branch to use. If not specified, the branch from `LLVM.lock` file is used.'
-        required: false
-        default: ''
-        type: string
       # For more information about the supported sanitizers in Rust, see:
       # https://rustc-dev-guide.rust-lang.org/sanitizers.html
       rust-sanitizer:
@@ -64,22 +59,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Checkout submodules
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --force --depth=1 --recursive --checkout
           
       - name: Building solc
         if: inputs.target == 'evm' && inputs.toolchain == 'ir-llvm'
-        uses: matter-labs/era-compiler-ci/.github/actions/build-solc@main
+        uses: matter-labs/era-compiler-ci/.github/actions/build-solc@v1
         with:
           cmake-build-type: RelWithDebInfo
           working-dir: 'era-solidity'
           upload-testing-binary: false
-
-      - name: Checkout llvm
-        if: inputs.llvm-branch != ''
-        uses: actions/checkout@v4
-        with:
-          repository: matter-labs/era-compiler-llvm
-          ref: ${{ inputs.llvm-branch }}
-          path: llvm
 
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -74,6 +74,7 @@ jobs:
       matrix:
         target: [ 'eravm' ]
     with:
-      ccache-key-type: 'static' # rotate ccache key every month
+      ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, 'gnu') }}
       target-machine: ${{ matrix.target }}
       platforms-matrix: ${{ needs.prepare-matrix.outputs.matrix }}
+      clone-llvm: 'false'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,13 +42,21 @@ jobs:
     container:
       image: ghcr.io/matter-labs/zksync-llvm-runner:latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Checkout submodules
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --force --depth=1 --recursive --checkout
 
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
-          enable-assertions: true
-          ccache-key-type: static
+          clone-llvm: 'false'
+          ccache-key: 'llvm-Linux-X64-gnu'
 
       - name: Cargo checks
         uses: matter-labs/era-compiler-ci/.github/actions/cargo-check@v1
@@ -89,7 +97,7 @@ jobs:
   # If you would like to make a change to the integration tests workflow, please do it in the era-compiler-ci repository
   integration-tests:
     needs: target-machine
-    uses: matter-labs/era-compiler-ci/.github/workflows/integration-tests.yaml@main
+    uses: matter-labs/era-compiler-ci/.github/workflows/integration-tests.yaml@v1
     secrets: inherit
     strategy:
       fail-fast: false
@@ -99,13 +107,14 @@ jobs:
       compiler-tester-repo: ${{ github.event.pull_request.head.repo.full_name }} # required to properly test forks
       ccache-key: 'llvm-Linux-X64-gnu'
       target-machine: ${{ matrix.target }}
+      clone-llvm: 'false'
 
   # Benchmarks workflow call from the era-compiler-ci repository
   # This is a common part of the benchmarks workflow for all repositories
   # If you would like to make a change to the benchmarks workflow, please do it in the era-compiler-ci repository
   benchmarks:
     needs: target-machine
-    uses: matter-labs/era-compiler-ci/.github/workflows/benchmarks.yml@main
+    uses: matter-labs/era-compiler-ci/.github/workflows/benchmarks.yml@v1
     secrets: inherit
     strategy:
       fail-fast: false
@@ -124,6 +133,7 @@ jobs:
       target-machine: ${{ matrix.target }}
       toolchain: ${{ matrix.toolchain }}
       environment: ${{ matrix.target == 'eravm' && 'zk_evm' || 'EVMInterpreter' }}
+      clone-llvm: 'false'
 
   # Special job that allows some of the jobs to be skipped or failed
   # requiring others to be successful

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,6 @@
 # /Cargo.lock
 # /LLVM.lock
 
-# LLVM framework source
-/llvm/
-
 # External compilers
 /solc-bin*/
 /vyper-bin*/

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,8 @@
     path = era-solidity
     url = https://github.com/matter-labs/era-solidity
     branch = 0.8.30
+[submodule "llvm"]
+    path = llvm
+    url = https://github.com/matter-labs/era-compiler-llvm
+    branch = main
+    update = none

--- a/LLVM.lock
+++ b/LLVM.lock
@@ -1,2 +1,0 @@
-url = "https://github.com/matter-labs/era-compiler-llvm"
-branch = "main"


### PR DESCRIPTION
# What ❔

* [x] Support llvm as a git submodule.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To simplify setup without the need of `zksync-llvm` to clone LLVM.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
