### PR TITLE
feat: XLSX reports for compiler-tester benchmarks

### DIFF
--- a/benchmark_analyzer/src/input/error.rs
+++ b/benchmark_analyzer/src/input/error.rs
@@ -1,0 +1,34 @@
+//!
+//! Benchmark input format.
+//!
+
+use std::path::PathBuf;
+
+///
+/// Input report reading error.
+///
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error reading the input file.
+    #[error("Reading input file {path:?}: {error}")]
+    Reading {
+        /// The underlying IO error.
+        error: std::io::Error,
+        /// The path to the input file.
+        path: PathBuf,
+    },
+    /// Error parsing the input file.
+    #[error("Parsing input file {path:?}: {error}")]
+    Parsing {
+        /// The underlying JSON parsing error.
+        error: serde_json::Error,
+        /// The path to the input file.
+        path: PathBuf,
+    },
+    /// Empty file error.
+    #[error("Input file {path:?} is empty")]
+    EmptyFile {
+        /// The path to the input file.
+        path: PathBuf,
+    },
+}

--- a/benchmark_analyzer/src/input/mod.rs
+++ b/benchmark_analyzer/src/input/mod.rs
@@ -2,14 +2,16 @@
 //! Benchmark input format.
 //!
 
+pub mod error;
 pub mod foundry_gas;
 pub mod foundry_size;
 
 use std::path::Path;
-use std::path::PathBuf;
 
+use self::error::Error as InputError;
 use self::foundry_gas::FoundryGasReport;
 use self::foundry_size::FoundrySizeReport;
+use crate::model::benchmark::Benchmark;
 
 ///
 /// Benchmark input format.
@@ -33,51 +35,30 @@ pub struct Input {
 #[derive(Debug, serde::Deserialize)]
 #[serde(untagged)]
 pub enum Report {
+    /// Benchmark converter's native benchmark report format.
+    Native(Benchmark),
     /// Foundry gas report.
     FoundryGas(FoundryGasReport),
     /// Foundry size report.
     FoundrySize(FoundrySizeReport),
 }
 
+impl From<Benchmark> for Report {
+    fn from(benchmark: Benchmark) -> Self {
+        Self::Native(benchmark)
+    }
+}
+
 impl From<FoundryGasReport> for Report {
     fn from(foundry_gas_report: FoundryGasReport) -> Self {
-        Report::FoundryGas(foundry_gas_report)
+        Self::FoundryGas(foundry_gas_report)
     }
 }
 
 impl From<FoundrySizeReport> for Report {
     fn from(foundry_size_report: FoundrySizeReport) -> Self {
-        Report::FoundrySize(foundry_size_report)
+        Self::FoundrySize(foundry_size_report)
     }
-}
-
-///
-/// Input report reading error.
-///
-#[derive(Debug, thiserror::Error)]
-pub enum InputError {
-    /// Error reading the input file.
-    #[error("Reading input file {path:?}: {error}")]
-    Reading {
-        /// The underlying IO error.
-        error: std::io::Error,
-        /// The path to the input file.
-        path: PathBuf,
-    },
-    /// Error parsing the input file.
-    #[error("Parsing input file {path:?}: {error}")]
-    Parsing {
-        /// The underlying JSON parsing error.
-        error: serde_json::Error,
-        /// The path to the input file.
-        path: PathBuf,
-    },
-    /// Empty file error.
-    #[error("Input file {path:?} is empty")]
-    EmptyFile {
-        /// The path to the input file.
-        path: PathBuf,
-    },
 }
 
 impl TryFrom<&Path> for Input {

--- a/benchmark_analyzer/src/lib.rs
+++ b/benchmark_analyzer/src/lib.rs
@@ -12,9 +12,9 @@ pub mod output;
 pub mod results;
 pub mod util;
 
+pub use crate::input::error::Error as InputReportError;
 pub use crate::input::foundry_gas::FoundryGasReport;
 pub use crate::input::Input as InputReport;
-pub use crate::input::InputError as InputReportError;
 pub use crate::model::benchmark::metadata::Metadata as BenchmarkMetadata;
 pub use crate::model::benchmark::test::input::Input;
 pub use crate::model::benchmark::test::metadata::Metadata as TestMetadata;

--- a/benchmark_analyzer/src/model/benchmark/test/toolchain/codegen/versioned/executable/run.rs
+++ b/benchmark_analyzer/src/model/benchmark/test/toolchain/codegen/versioned/executable/run.rs
@@ -31,6 +31,28 @@ pub struct Run {
 
 impl Run {
     ///
+    /// Extends the run with another run, averaging the values.
+    ///
+    pub fn extend(&mut self, other: &Self) {
+        self.size.extend_from_slice(other.size.as_slice());
+        self.runtime_size
+            .extend_from_slice(other.runtime_size.as_slice());
+        self.cycles.extend_from_slice(other.cycles.as_slice());
+        self.ergs.extend(
+            other
+                .ergs
+                .iter()
+                .filter(|value| value < &&(u32::MAX as u64)),
+        );
+        self.gas.extend(
+            other
+                .ergs
+                .iter()
+                .filter(|value| value < &&(u32::MAX as u64)),
+        );
+    }
+
+    ///
     /// Average contract size.
     ///
     pub fn average_size(&self) -> u64 {

--- a/benchmark_analyzer/src/output/xlsx/mod.rs
+++ b/benchmark_analyzer/src/output/xlsx/mod.rs
@@ -117,9 +117,13 @@ impl TryFrom<Benchmark> for Xlsx {
                 .and_then(|input| input.runtime_name());
 
             for (toolchain_name, toolchain_group) in test.toolchain_groups.into_iter() {
-                for codegen_group in toolchain_group.codegen_groups.into_values() {
-                    for version_group in codegen_group.versioned_groups.into_values() {
-                        for optimization_group in version_group.executables.into_values() {
+                for (codegen_name, codegen_group) in toolchain_group.codegen_groups.into_iter() {
+                    for (version_name, version_group) in codegen_group.versioned_groups.into_iter()
+                    {
+                        for (optimization_name, optimization_group) in
+                            version_group.executables.into_iter()
+                        {
+                            let toolchain_name = format!("{toolchain_name}-{version_name}-{codegen_name}-{optimization_name}");
                             let toolchain_id = xlsx.get_toolchain_id(toolchain_name.as_str());
 
                             if is_deployer {
@@ -185,9 +189,8 @@ impl TryFrom<Benchmark> for Xlsx {
             .set_totals(xlsx.toolchain_ids.len())?;
 
         for (index, (toolchain_id_1, toolchain_id_2)) in
-            [(6, 4), (7, 5), (6, 2), (7, 3), (6, 0), (7, 1)]
-                .into_iter()
-                .enumerate()
+            // [(6, 4), (7, 5), (6, 2), (7, 3), (6, 0), (7, 1)]
+            [(6, 2), (7, 3), (4, 0), (5, 1)].into_iter().enumerate()
         {
             xlsx.runtime_gas_worksheet.set_diffs(
                 toolchain_id_1,


### PR DESCRIPTION
# What ❔

Supports XLSX reports with compiler-tester benchmarks.

## Why ❔

We want to unify reports from Foundry, Hardhat, and compiler-tester.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
