### PR TITLE
chore: begin splitting EraVM and EVM codebases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -763,6 +763,7 @@ dependencies = [
  "serde_yaml",
  "sha3 0.10.8",
  "solidity-adapter",
+ "solx-codegen-evm",
  "solx-standard-json",
  "solx-utils",
  "web3",
@@ -773,15 +774,14 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccd746bf9b1038c0507b7cec21eb2b11222db96a2902c96e8c185d6d20fb9c4"
+checksum = "b6407bff74dea37e0fa3dc1c1c974e5d46405f0c987bf9997a0762adce71eda6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "hex",
  "proptest",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1146,7 +1146,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "era-compiler-common"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#c7c7cb3d92f1c185daa52f7868594763385085e9"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#4a0cf2ef09ce69ca87b780cd163f8f9aae52ac89"
 dependencies = [
  "anyhow",
  "base58",
@@ -1163,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-downloader"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#c7c7cb3d92f1c185daa52f7868594763385085e9"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#4a0cf2ef09ce69ca87b780cd163f8f9aae52ac89"
 dependencies = [
  "anyhow",
  "colored",
@@ -1176,24 +1176,22 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#8d3042b6c29fe2cab9aa43333e388b8798011f58"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#68e4674db2c5030d589d758582e9c12ecf12b8a2"
 dependencies = [
  "anyhow",
  "era-compiler-common",
- "indexmap",
  "inkwell",
  "itertools 0.14.0",
  "num",
  "semver 1.0.26",
  "serde",
- "thiserror 2.0.16",
  "zkevm_opcode_defs 0.152.7 (git+https://github.com/matter-labs/zksync-protocol?branch=main)",
 ]
 
 [[package]]
 name = "era-compiler-solidity"
 version = "1.5.16"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#9a94dc1962b1712d5bd5072b39ad87bab26f0028"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#f6ab9d80b17b903d814a785da9612c6874926efc"
 dependencies = [
  "anyhow",
  "clap",
@@ -1218,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-vyper"
 version = "1.5.11"
-source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#6d9ce891a1007e23e5d1590560cdc53e2ecb63f0"
+source = "git+https://github.com/matter-labs/era-compiler-vyper?branch=main#178d18fc81ab16bd76db0ce2bf89a87930ae9861"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -1241,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "era-solc"
 version = "1.5.16"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#9a94dc1962b1712d5bd5072b39ad87bab26f0028"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#f6ab9d80b17b903d814a785da9612c6874926efc"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -1258,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "era-yul"
 version = "1.5.16"
-source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#9a94dc1962b1712d5bd5072b39ad87bab26f0028"
+source = "git+https://github.com/matter-labs/era-compiler-solidity?branch=main#f6ab9d80b17b903d814a785da9612c6874926efc"
 dependencies = [
  "anyhow",
  "regex",
@@ -1798,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2600,9 +2598,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
 dependencies = [
  "memchr",
  "thiserror 2.0.16",
@@ -3426,10 +3424,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3443,10 +3442,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3455,15 +3463,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "56177480b00303e689183f110b4e727bb4211d692c62d4fcd16d02be93077d40"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3633,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "solx-codegen-evm"
 version = "0.1.2"
-source = "git+https://github.com/matter-labs/solx?branch=main#9cf821e04d59fb91d12dabdc12eb2044913e169f"
+source = "git+https://github.com/matter-labs/solx?branch=main#c6aedce5cd0f9037cfcd684dd9295ffb0553c82e"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3649,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "solx-evm-assembly"
 version = "0.1.2"
-source = "git+https://github.com/matter-labs/solx?branch=main#9cf821e04d59fb91d12dabdc12eb2044913e169f"
+source = "git+https://github.com/matter-labs/solx?branch=main#c6aedce5cd0f9037cfcd684dd9295ffb0553c82e"
 dependencies = [
  "anyhow",
  "ciborium",
@@ -3668,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "solx-standard-json"
 version = "0.1.2"
-source = "git+https://github.com/matter-labs/solx?branch=main#9cf821e04d59fb91d12dabdc12eb2044913e169f"
+source = "git+https://github.com/matter-labs/solx?branch=main#c6aedce5cd0f9037cfcd684dd9295ffb0553c82e"
 dependencies = [
  "anyhow",
  "num",
@@ -3683,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "solx-utils"
 version = "0.1.2"
-source = "git+https://github.com/matter-labs/solx?branch=main#9cf821e04d59fb91d12dabdc12eb2044913e169f"
+source = "git+https://github.com/matter-labs/solx?branch=main#c6aedce5cd0f9037cfcd684dd9295ffb0553c82e"
 dependencies = [
  "anyhow",
  "base58",
@@ -3700,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "solx-yul"
 version = "0.1.2"
-source = "git+https://github.com/matter-labs/solx?branch=main#9cf821e04d59fb91d12dabdc12eb2044913e169f"
+source = "git+https://github.com/matter-labs/solx?branch=main#c6aedce5cd0f9037cfcd684dd9295ffb0553c82e"
 dependencies = [
  "anyhow",
  "serde",
@@ -4430,15 +4438,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
@@ -4482,8 +4490,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4496,12 +4504,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/benchmark_analyzer/src/analysis/mod.rs
+++ b/benchmark_analyzer/src/analysis/mod.rs
@@ -24,8 +24,8 @@ type GroupRuns<'a> = BTreeMap<&'a str, (RunDescription<'a>, &'a Run)>;
 /// Collects measurements from a benchmark into groups.
 /// Groups may intersect.
 ///
-fn collect_runs(benchmark: &Benchmark) -> BTreeMap<Group<'_>, GroupRuns> {
-    let mut result: BTreeMap<Group<'_>, GroupRuns> = BTreeMap::new();
+fn collect_runs(benchmark: &Benchmark) -> BTreeMap<Group<'_>, GroupRuns<'_>> {
+    let mut result: BTreeMap<Group<'_>, GroupRuns<'_>> = BTreeMap::new();
     for (test_identifier, test) in benchmark.tests.iter() {
         for (_toolchain, toolchain_group) in test.toolchain_groups.iter() {
             for (codegen, codegen_group) in toolchain_group.codegen_groups.iter() {

--- a/benchmark_analyzer/src/benchmark_converter/tests.rs
+++ b/benchmark_analyzer/src/benchmark_converter/tests.rs
@@ -13,7 +13,7 @@ fn convert() {
         toolchain: "solx".to_owned(),
         compiler_version: semver::Version::new(1, 0, 0).to_string(),
         llvm_version: semver::Version::new(19, 1, 0).to_string(),
-        target: era_compiler_common::Target::EVM,
+        target: benchmark_analyzer::Target::EVM,
 
         codegen: Some("Y+".to_owned()),
         optimization: Some("M3B3".to_owned()),

--- a/benchmark_analyzer/src/lib.rs
+++ b/benchmark_analyzer/src/lib.rs
@@ -10,6 +10,7 @@ pub mod input;
 pub mod model;
 pub mod output;
 pub mod results;
+pub mod target;
 pub mod util;
 
 pub use crate::input::error::Error as InputReportError;
@@ -35,3 +36,4 @@ pub use crate::output::json::lnt::JsonLNT as JsonLNTOutput;
 pub use crate::output::json::Json as JsonNativeOutput;
 pub use crate::output::Output;
 pub use crate::results::group::Group as ResultsGroup;
+pub use crate::target::Target;

--- a/benchmark_analyzer/src/model/context.rs
+++ b/benchmark_analyzer/src/model/context.rs
@@ -4,6 +4,8 @@
 
 use std::path::PathBuf;
 
+use crate::target::Target;
+
 ///
 /// A context for benchmarking, passed by compiler-tester.
 ///
@@ -18,7 +20,7 @@ pub struct Context {
     /// Version of the LLVM backend.
     pub llvm_version: String,
     /// Target, such as `evm` or `eravm`.
-    pub target: era_compiler_common::Target,
+    pub target: Target,
 
     /// Global codegen setting.
     pub codegen: Option<String>,
@@ -33,7 +35,7 @@ impl Default for Context {
             toolchain: "unknown".to_string(),
             compiler_version: "unknown".to_string(),
             llvm_version: "unknown".to_string(),
-            target: era_compiler_common::Target::EVM,
+            target: Target::EVM,
             codegen: Some("unknown".to_string()),
             optimization: Some("unknown".to_string()),
         }

--- a/benchmark_analyzer/src/output/json/lnt/benchmark/machine.rs
+++ b/benchmark_analyzer/src/output/json/lnt/benchmark/machine.rs
@@ -2,6 +2,8 @@
 //! LNT machine description.
 //!
 
+use crate::target::Target;
+
 ///
 /// Description of the `machine` section in the JSON file generated for LNT.
 /// See https://llvm.org/docs/lnt/importing_data.html
@@ -11,7 +13,7 @@ pub struct Machine {
     /// Machine name, such as `llvm_eravm_ir-llvm_Y+M3B3`.
     pub name: String,
     /// Target name, such as `eravm` or `evm`.
-    pub target: era_compiler_common::Target,
+    pub target: Target,
     /// Code generation, such as `Y+`.
     pub codegen: String,
     /// Optimization levels, such as `M3B3`.

--- a/benchmark_analyzer/src/target.rs
+++ b/benchmark_analyzer/src/target.rs
@@ -1,0 +1,58 @@
+//!
+//! Compilation target.
+//!
+
+use std::str::FromStr;
+
+///
+/// Compilation target.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Target {
+    /// The EraVM target.
+    EraVM,
+    /// The EVM target.
+    EVM,
+}
+
+impl Target {
+    ///
+    /// Returns the LLVM target triple.
+    ///
+    pub fn triple(&self) -> &str {
+        match self {
+            Self::EraVM => "eravm-unknown-unknown",
+            Self::EVM => "evm-unknown-unknown",
+        }
+    }
+}
+
+impl FromStr for Target {
+    type Err = anyhow::Error;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        match string {
+            "eravm" => Ok(Self::EraVM),
+            "evm" => Ok(Self::EVM),
+            _ => Err(anyhow::anyhow!(
+                "Unknown target `{}`. Supported targets: {}",
+                string,
+                vec![Self::EraVM, Self::EVM]
+                    .into_iter()
+                    .map(|target| target.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Target::EraVM => write!(f, "eravm"),
+            Target::EVM => write!(f, "evm"),
+        }
+    }
+}

--- a/compiler_tester/Cargo.toml
+++ b/compiler_tester/Cargo.toml
@@ -49,6 +49,7 @@ era-compiler-solidity = { git = "https://github.com/matter-labs/era-compiler-sol
 era-solc = { git = "https://github.com/matter-labs/era-compiler-solidity", branch = "main" }
 era-compiler-vyper = { git = "https://github.com/matter-labs/era-compiler-vyper", branch = "main" }
 solx-standard-json = { git = "https://github.com/matter-labs/solx", branch = "main" }
+solx-codegen-evm = { git = "https://github.com/matter-labs/solx", branch = "main" }
 solx-utils = { git = "https://github.com/matter-labs/solx", branch = "main" }
 
 solidity-adapter = { path = "../solidity_adapter" }

--- a/compiler_tester/src/compiler_tester/arguments.rs
+++ b/compiler_tester/src/compiler_tester/arguments.rs
@@ -90,7 +90,7 @@ pub struct Arguments {
     /// Specify the target architecture.
     /// Available arguments: `evm`, `eravm`.
     #[structopt(long)]
-    pub target: era_compiler_common::Target,
+    pub target: benchmark_analyzer::Target,
 
     /// Specify the environment to run tests on.
     /// Available arguments: `zk_evm`, `FastVM`, `EVMInterpreter`, `REVM`.

--- a/compiler_tester/src/compiler_tester/main.rs
+++ b/compiler_tester/src/compiler_tester/main.rs
@@ -48,14 +48,8 @@ fn main_inner(arguments: Arguments) -> anyhow::Result<()> {
     );
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    for target in [
-        era_compiler_common::Target::EraVM,
-        era_compiler_common::Target::EVM,
-    ]
-    .into_iter()
-    {
-        era_compiler_llvm_context::initialize_target(target);
-    }
+    era_compiler_llvm_context::initialize_target();
+    solx_codegen_evm::initialize_target();
     compiler_tester::LLVMOptions::initialize(
         arguments.llvm_verify_each,
         arguments.llvm_debug_logging,
@@ -100,22 +94,19 @@ fn main_inner(arguments: Arguments) -> anyhow::Result<()> {
         .unwrap_or(compiler_tester::Toolchain::IrLLVM);
     let environment = match (target, arguments.environment) {
         (
-            era_compiler_common::Target::EraVM,
+            benchmark_analyzer::Target::EraVM,
             Some(environment @ compiler_tester::Environment::ZkEVM),
         ) => environment,
-        (era_compiler_common::Target::EraVM, Some(compiler_tester::Environment::FastVM)) => {
-            anyhow::bail!("FastVM is not supported yet");
-        }
-        (era_compiler_common::Target::EraVM, None) => compiler_tester::Environment::ZkEVM,
+        (benchmark_analyzer::Target::EraVM, None) => compiler_tester::Environment::ZkEVM,
         (
-            era_compiler_common::Target::EVM,
+            benchmark_analyzer::Target::EVM,
             Some(environment @ compiler_tester::Environment::EVMInterpreter),
         ) => environment,
         (
-            era_compiler_common::Target::EVM,
+            benchmark_analyzer::Target::EVM,
             Some(environment @ compiler_tester::Environment::REVM),
         ) => environment,
-        (era_compiler_common::Target::EVM, None) => compiler_tester::Environment::EVMInterpreter,
+        (benchmark_analyzer::Target::EVM, None) => compiler_tester::Environment::EVMInterpreter,
         (target, Some(environment)) => anyhow::bail!(
             "Target `{target}` and environment `{environment}` combination is not supported"
         ),
@@ -123,8 +114,8 @@ fn main_inner(arguments: Arguments) -> anyhow::Result<()> {
 
     let mut executable_download_config_paths = Vec::with_capacity(2);
     if let Some(path) = match (target, toolchain) {
-        (era_compiler_common::Target::EVM, compiler_tester::Toolchain::IrLLVM) => None,
-        (era_compiler_common::Target::EraVM, compiler_tester::Toolchain::IrLLVM) => {
+        (benchmark_analyzer::Target::EVM, compiler_tester::Toolchain::IrLLVM) => None,
+        (benchmark_analyzer::Target::EraVM, compiler_tester::Toolchain::IrLLVM) => {
             Some("./configs/solc-bin-default.json")
         }
         (_, compiler_tester::Toolchain::Zksolc) => Some("./configs/solc-bin-default.json"),
@@ -191,7 +182,6 @@ fn main_inner(arguments: Arguments) -> anyhow::Result<()> {
                     .run_eravm::<compiler_tester::EraVMSystemContractDeployer, true>(vm, toolchain),
             }
         }
-        compiler_tester::Environment::FastVM => anyhow::bail!("FastVM is not supported yet"),
         compiler_tester::Environment::EVMInterpreter => {
             let system_contract_debug_config = if arguments.dump_system {
                 debug_config
@@ -275,7 +265,7 @@ mod tests {
             zkvyper: None,
             solx: Some(PathBuf::from("solx")),
             toolchain: Some(compiler_tester::Toolchain::IrLLVM),
-            target: era_compiler_common::Target::EVM,
+            target: benchmark_analyzer::Target::EVM,
             environment: None,
             workflow: compiler_tester::Workflow::BuildAndRun,
             solc_bin_config_path: Some(PathBuf::from("./configs/solc-bin-default.json")),

--- a/compiler_tester/src/compilers/eravm_assembly/mod.rs
+++ b/compiler_tester/src/compilers/eravm_assembly/mod.rs
@@ -48,7 +48,7 @@ impl Compiler for EraVMAssemblyCompiler {
         let build = project.compile_to_eravm(
             &mut vec![],
             true,
-            era_compiler_common::EraVMMetadataHashType::IPFS,
+            era_compiler_common::MetadataHashType::IPFS,
             true,
             era_compiler_llvm_context::OptimizerSettings::none(),
             llvm_options,
@@ -80,7 +80,7 @@ impl Compiler for EraVMAssemblyCompiler {
         anyhow::bail!("EraVM assembly cannot be compiled to EVM");
     }
 
-    fn all_modes(&self, _target: era_compiler_common::Target) -> Vec<Mode> {
+    fn all_modes(&self) -> Vec<Mode> {
         vec![EraVMMode::default().into()]
     }
 

--- a/compiler_tester/src/compilers/llvm_ir/mod.rs
+++ b/compiler_tester/src/compilers/llvm_ir/mod.rs
@@ -62,7 +62,7 @@ impl Compiler for LLVMIRCompiler {
         let build = project.compile_to_eravm(
             &mut vec![],
             true,
-            era_compiler_common::EraVMMetadataHashType::IPFS,
+            era_compiler_common::MetadataHashType::IPFS,
             true,
             mode.llvm_optimizer_settings.to_owned(),
             llvm_options,
@@ -177,10 +177,22 @@ impl Compiler for LLVMIRCompiler {
         Ok(EVMInput::new(builds, None, last_contract))
     }
 
-    fn all_modes(&self, target: era_compiler_common::Target) -> Vec<Mode> {
-        era_compiler_llvm_context::OptimizerSettings::combinations(target)
+    fn all_modes(&self) -> Vec<Mode> {
+        solx_codegen_evm::OptimizerSettings::combinations()
             .into_iter()
-            .map(|llvm_optimizer_settings| LLVMMode::new(llvm_optimizer_settings).into())
+            .map(|llvm_optimizer_settings| {
+                let llvm_optimizer_settings = era_compiler_llvm_context::OptimizerSettings::new(
+                    llvm_optimizer_settings.level_middle_end,
+                    match llvm_optimizer_settings.level_middle_end_size as u32 {
+                        0 => era_compiler_llvm_context::OptimizerSettingsSizeLevel::Zero,
+                        1 => era_compiler_llvm_context::OptimizerSettingsSizeLevel::S,
+                        2 => era_compiler_llvm_context::OptimizerSettingsSizeLevel::Z,
+                        _ => panic!("Invalid size level"),
+                    },
+                    llvm_optimizer_settings.level_back_end,
+                );
+                LLVMMode::new(llvm_optimizer_settings).into()
+            })
             .collect::<Vec<Mode>>()
     }
 

--- a/compiler_tester/src/compilers/mod.rs
+++ b/compiler_tester/src/compilers/mod.rs
@@ -49,7 +49,7 @@ pub trait Compiler: Send + Sync + 'static {
     ///
     /// Returns all supported combinations of compiler settings.
     ///
-    fn all_modes(&self, target: era_compiler_common::Target) -> Vec<Mode>;
+    fn all_modes(&self) -> Vec<Mode>;
 
     ///
     /// Whether one source file can contains multiple contracts.

--- a/compiler_tester/src/compilers/solidity/solx/mod.rs
+++ b/compiler_tester/src/compilers/solidity/solx/mod.rs
@@ -342,16 +342,26 @@ impl Compiler for SolidityCompiler {
         ))
     }
 
-    fn all_modes(&self, target: era_compiler_common::Target) -> Vec<Mode> {
+    fn all_modes(&self) -> Vec<Mode> {
         let mut solc_codegen_versions = Vec::new();
         for via_ir in [false, true] {
             solc_codegen_versions.push((via_ir, self.version.to_owned()));
         }
 
-        era_compiler_llvm_context::OptimizerSettings::combinations(target)
+        solx_codegen_evm::OptimizerSettings::combinations()
             .into_iter()
             .cartesian_product(solc_codegen_versions)
             .map(|(llvm_optimizer_settings, (via_ir, version))| {
+                let llvm_optimizer_settings = era_compiler_llvm_context::OptimizerSettings::new(
+                    llvm_optimizer_settings.level_middle_end,
+                    match llvm_optimizer_settings.level_middle_end_size as u32 {
+                        0 => era_compiler_llvm_context::OptimizerSettingsSizeLevel::Zero,
+                        1 => era_compiler_llvm_context::OptimizerSettingsSizeLevel::S,
+                        2 => era_compiler_llvm_context::OptimizerSettingsSizeLevel::Z,
+                        _ => panic!("Invalid size level"),
+                    },
+                    llvm_optimizer_settings.level_back_end,
+                );
                 SolxMode::new(version, via_ir, false, llvm_optimizer_settings).into()
             })
             .collect::<Vec<Mode>>()

--- a/compiler_tester/src/compilers/solidity/zksolc/mod.rs
+++ b/compiler_tester/src/compilers/solidity/zksolc/mod.rs
@@ -341,7 +341,7 @@ impl Compiler for SolidityCompiler {
         let build = project.compile_to_eravm(
             &mut vec![],
             mode.enable_eravm_extensions,
-            era_compiler_common::EraVMMetadataHashType::IPFS,
+            era_compiler_common::MetadataHashType::IPFS,
             true,
             mode.llvm_optimizer_settings.to_owned(),
             llvm_options,
@@ -396,7 +396,7 @@ impl Compiler for SolidityCompiler {
         unimplemented!()
     }
 
-    fn all_modes(&self, target: era_compiler_common::Target) -> Vec<Mode> {
+    fn all_modes(&self) -> Vec<Mode> {
         let mut solc_codegen_versions = Vec::new();
         for (codegen, via_ir) in [
             (era_solc::StandardJsonInputCodegen::EVMLA, false),
@@ -410,7 +410,7 @@ impl Compiler for SolidityCompiler {
             }
         }
 
-        era_compiler_llvm_context::OptimizerSettings::combinations(target)
+        era_compiler_llvm_context::OptimizerSettings::combinations()
             .into_iter()
             .cartesian_product(solc_codegen_versions)
             .map(

--- a/compiler_tester/src/compilers/vyper/mod.rs
+++ b/compiler_tester/src/compilers/vyper/mod.rs
@@ -208,7 +208,7 @@ impl Compiler for VyperCompiler {
 
         let mut build = project.compile(
             None,
-            era_compiler_common::EraVMMetadataHashType::IPFS,
+            era_compiler_common::MetadataHashType::IPFS,
             false,
             mode.llvm_optimizer_settings.to_owned(),
             llvm_options,
@@ -250,11 +250,11 @@ impl Compiler for VyperCompiler {
         anyhow::bail!("Vyper cannot be compiled to EVM");
     }
 
-    fn all_modes(&self, target: era_compiler_common::Target) -> Vec<Mode> {
+    fn all_modes(&self) -> Vec<Mode> {
         let vyper_versions =
             VyperCompiler::all_versions().expect("`vyper` versions analysis error");
 
-        era_compiler_llvm_context::OptimizerSettings::combinations(target)
+        era_compiler_llvm_context::OptimizerSettings::combinations()
             .into_iter()
             .cartesian_product(vyper_versions)
             .cartesian_product(vec![false, true])

--- a/compiler_tester/src/directories/ethereum/mod.rs
+++ b/compiler_tester/src/directories/ethereum/mod.rs
@@ -49,19 +49,19 @@ impl Collection for EthereumDirectory {
     type Test = EthereumTest;
 
     fn read_all(
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
         directory_path: &Path,
         _extension: &'static str,
         summary: Arc<Mutex<Summary>>,
         filters: &Filters,
     ) -> anyhow::Result<Vec<Self::Test>> {
         let index_path = match target {
-            era_compiler_common::Target::EraVM => {
+            benchmark_analyzer::Target::EraVM => {
                 let mut index_path = directory_path.to_path_buf();
                 index_path.push(Self::INDEX_NAME_ZKSYNC);
                 index_path
             }
-            era_compiler_common::Target::EVM => PathBuf::from(Self::INDEX_NAME_UPSTREAM),
+            benchmark_analyzer::Target::EVM => PathBuf::from(Self::INDEX_NAME_UPSTREAM),
         };
 
         Ok(Self::read_index(index_path.as_path())?

--- a/compiler_tester/src/directories/ethereum/test.rs
+++ b/compiler_tester/src/directories/ethereum/test.rs
@@ -271,7 +271,7 @@ impl Buildable for EthereumTest {
             &calls,
             instances,
             last_source.as_str(),
-            era_compiler_common::Target::EraVM,
+            benchmark_analyzer::Target::EraVM,
         ) {
             Ok(case) => case,
             Err(error) => {
@@ -374,7 +374,7 @@ impl Buildable for EthereumTest {
             &calls,
             instances,
             last_source.as_str(),
-            era_compiler_common::Target::EVM,
+            benchmark_analyzer::Target::EVM,
         ) {
             Ok(case) => case,
             Err(error) => {

--- a/compiler_tester/src/directories/matter_labs/mod.rs
+++ b/compiler_tester/src/directories/matter_labs/mod.rs
@@ -24,7 +24,7 @@ impl Collection for MatterLabsDirectory {
     type Test = MatterLabsTest;
 
     fn read_all(
-        _target: era_compiler_common::Target,
+        _target: benchmark_analyzer::Target,
         directory_path: &Path,
         extension: &'static str,
         summary: Arc<Mutex<Summary>>,

--- a/compiler_tester/src/directories/matter_labs/test/metadata/case/mod.rs
+++ b/compiler_tester/src/directories/matter_labs/test/metadata/case/mod.rs
@@ -101,7 +101,7 @@ impl Case {
             }
         }
 
-        if let era_compiler_common::Target::EraVM = environment.into() {
+        if let benchmark_analyzer::Target::EraVM = environment.into() {
             for (name, instance) in instances.iter() {
                 if let Instance::EraVM { .. } = instance {
                     continue;

--- a/compiler_tester/src/directories/matter_labs/test/metadata/mod.rs
+++ b/compiler_tester/src/directories/matter_labs/test/metadata/mod.rs
@@ -19,7 +19,7 @@ pub struct Metadata {
     /// The test cases.
     pub cases: Vec<Case>,
     /// The target filter.
-    pub targets: Option<Vec<era_compiler_common::Target>>,
+    pub targets: Option<Vec<benchmark_analyzer::Target>>,
     /// The mode filter.
     pub modes: Option<Vec<String>>,
     /// The test group.

--- a/compiler_tester/src/directories/matter_labs/test/mod.rs
+++ b/compiler_tester/src/directories/matter_labs/test/mod.rs
@@ -205,7 +205,7 @@ impl MatterLabsTest {
         &self,
         filters: &Filters,
         mode: &Mode,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> Option<()> {
         if let Some(targets) = self.metadata.targets.as_ref() {
             if !targets.contains(&target) {
@@ -422,7 +422,7 @@ impl Buildable for MatterLabsTest {
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> Option<Test> {
         mode.enable_eravm_extensions(self.metadata.enable_eravm_extensions);
-        self.check_filters(filters, &mode, era_compiler_common::Target::EraVM)?;
+        self.check_filters(filters, &mode, benchmark_analyzer::Target::EraVM)?;
 
         let mut contracts = self.metadata.contracts.clone();
         self.push_default_contract(&mut contracts, compiler.allows_multi_contract_files());
@@ -519,7 +519,7 @@ impl Buildable for MatterLabsTest {
                 &mode,
                 &instances,
                 &eravm_input.method_identifiers,
-                era_compiler_common::Target::EraVM,
+                benchmark_analyzer::Target::EraVM,
             )
             .map_err(|error| anyhow::anyhow!("Case `{case_name}` is invalid: {error}"))
             {
@@ -565,7 +565,7 @@ impl Buildable for MatterLabsTest {
         filters: &Filters,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> Option<Test> {
-        self.check_filters(filters, &mode, era_compiler_common::Target::EVM)?;
+        self.check_filters(filters, &mode, benchmark_analyzer::Target::EVM)?;
 
         let mut contracts = self.metadata.contracts.clone();
         self.push_default_contract(&mut contracts, compiler.allows_multi_contract_files());
@@ -646,7 +646,7 @@ impl Buildable for MatterLabsTest {
                 &mode,
                 &instances,
                 &evm_input.method_identifiers,
-                era_compiler_common::Target::EVM,
+                benchmark_analyzer::Target::EVM,
             )
             .map_err(|error| anyhow::anyhow!("Case `{}` is invalid: {}", case_name, error))
             {

--- a/compiler_tester/src/directories/mod.rs
+++ b/compiler_tester/src/directories/mod.rs
@@ -29,7 +29,7 @@ pub trait Collection {
     /// Returns all directory tests.
     ///
     fn read_all(
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
         directory_path: &Path,
         extension: &'static str,
         summary: Arc<Mutex<Summary>>,

--- a/compiler_tester/src/environment.rs
+++ b/compiler_tester/src/environment.rs
@@ -9,8 +9,6 @@
 pub enum Environment {
     /// The old `zk_evm` EraVM.
     ZkEVM,
-    /// The new fast EraVM.
-    FastVM,
     /// The EraVM-based EVM interpreter.
     EVMInterpreter,
     /// The REVM implementation.
@@ -23,13 +21,12 @@ impl std::str::FromStr for Environment {
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         match string {
             "zk_evm" => Ok(Self::ZkEVM),
-            "FastVM" => Ok(Self::FastVM),
             "EVMInterpreter" => Ok(Self::EVMInterpreter),
             "REVM" => Ok(Self::REVM),
             string => anyhow::bail!(
                 "Unknown environment `{}`. Supported environments: {:?}",
                 string,
-                vec![Self::ZkEVM, Self::FastVM, Self::EVMInterpreter, Self::REVM]
+                vec![Self::ZkEVM, Self::EVMInterpreter, Self::REVM]
                     .into_iter()
                     .map(|element| element.to_string())
                     .collect::<Vec<String>>()
@@ -39,13 +36,12 @@ impl std::str::FromStr for Environment {
     }
 }
 
-impl From<Environment> for era_compiler_common::Target {
+impl From<Environment> for benchmark_analyzer::Target {
     fn from(environment: Environment) -> Self {
         match environment {
-            Environment::ZkEVM => era_compiler_common::Target::EraVM,
-            Environment::FastVM => era_compiler_common::Target::EraVM,
-            Environment::EVMInterpreter => era_compiler_common::Target::EVM,
-            Environment::REVM => era_compiler_common::Target::EVM,
+            Environment::ZkEVM => Self::EraVM,
+            Environment::EVMInterpreter => Self::EVM,
+            Environment::REVM => Self::EVM,
         }
     }
 }
@@ -54,7 +50,6 @@ impl std::fmt::Display for Environment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ZkEVM => write!(f, "zk_evm"),
-            Self::FastVM => write!(f, "FastVM"),
             Self::EVMInterpreter => write!(f, "EVMInterpreter"),
             Self::REVM => write!(f, "REVM"),
         }

--- a/compiler_tester/src/test/case/input/calldata.rs
+++ b/compiler_tester/src/test/case/input/calldata.rs
@@ -24,7 +24,7 @@ impl Calldata {
     pub fn try_from_matter_labs(
         calldata: MatterLabsTestInputCalldata,
         instances: &BTreeMap<String, Instance>,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Self> {
         let calldata = match calldata {
             MatterLabsTestInputCalldata::Value(value) => {

--- a/compiler_tester/src/test/case/input/mod.rs
+++ b/compiler_tester/src/test/case/input/mod.rs
@@ -62,7 +62,7 @@ impl Input {
         mode: &Mode,
         instances: &BTreeMap<String, Instance>,
         method_identifiers: &Option<BTreeMap<String, BTreeMap<String, u32>>>,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Self> {
         let caller = web3::types::Address::from_str(input.caller.as_str())
             .map_err(|error| anyhow::anyhow!("Invalid caller `{}`: {}", input.caller, error))?;
@@ -89,8 +89,8 @@ impl Input {
             .map_err(|error| anyhow::anyhow!("Invalid calldata: {}", error))?;
 
         let expected = match target {
-            era_compiler_common::Target::EraVM => input.expected_eravm.or(input.expected),
-            era_compiler_common::Target::EVM => input.expected_evm.or(input.expected),
+            benchmark_analyzer::Target::EraVM => input.expected_eravm.or(input.expected),
+            benchmark_analyzer::Target::EVM => input.expected_evm.or(input.expected),
         };
         let expected = match expected {
             Some(expected) => {
@@ -214,7 +214,7 @@ impl Input {
         instances: &BTreeMap<String, Instance>,
         last_source: &str,
         caller: &web3::types::Address,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Option<Self>> {
         let main_contract_instance = instances
             .values()

--- a/compiler_tester/src/test/case/input/output/event.rs
+++ b/compiler_tester/src/test/case/input/output/event.rs
@@ -44,7 +44,7 @@ impl Event {
     pub fn try_from_matter_labs(
         event: MatterLabsTestExpectedEvent,
         instances: &BTreeMap<String, Instance>,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Self> {
         let topics = Value::try_from_vec_matter_labs(event.topics, instances, target)
             .map_err(|error| anyhow::anyhow!("Invalid topics: {}", error))?;

--- a/compiler_tester/src/test/case/input/output/mod.rs
+++ b/compiler_tester/src/test/case/input/output/mod.rs
@@ -47,7 +47,7 @@ impl Output {
         expected: MatterLabsTestExpected,
         mode: &Mode,
         instances: &BTreeMap<String, Instance>,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Self> {
         let variants = match expected {
             MatterLabsTestExpected::Single(variant) => vec![variant],
@@ -106,13 +106,13 @@ impl Output {
         exception: bool,
         events: &[solidity_adapter::Event],
         contract_address: &web3::types::Address,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> Self {
         let return_data = expected
             .iter()
             .map(|value| {
                 let mut value_str = crate::utils::u256_as_string(value);
-                if let era_compiler_common::Target::EraVM = target {
+                if let benchmark_analyzer::Target::EraVM = target {
                     value_str = value_str.replace(
                         solidity_adapter::DEFAULT_CONTRACT_ADDRESS,
                         &crate::utils::address_as_string(contract_address),

--- a/compiler_tester/src/test/case/input/storage.rs
+++ b/compiler_tester/src/test/case/input/storage.rs
@@ -26,7 +26,7 @@ impl Storage {
     pub fn try_from_matter_labs(
         storage: HashMap<String, MatterLabsTestContractStorage>,
         instances: &BTreeMap<String, Instance>,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Self> {
         let mut result = HashMap::new();
 

--- a/compiler_tester/src/test/case/input/value.rs
+++ b/compiler_tester/src/test/case/input/value.rs
@@ -43,7 +43,7 @@ impl Value {
     pub fn try_from_matter_labs(
         value: String,
         instances: &BTreeMap<String, Instance>,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Self> {
         if value == "*" {
             return Ok(Self::Any);
@@ -77,29 +77,29 @@ impl Value {
                 .map_err(|error| anyhow::anyhow!("Invalid hexadecimal literal: {}", error))?
         } else if value == "$CHAIN_ID" {
             match target {
-                era_compiler_common::Target::EraVM => {
+                benchmark_analyzer::Target::EraVM => {
                     web3::types::U256::from(SystemContext::CHAIND_ID_ERAVM)
                 }
-                era_compiler_common::Target::EVM => {
+                benchmark_analyzer::Target::EVM => {
                     web3::types::U256::from(SystemContext::CHAIND_ID_EVM)
                 }
             }
         } else if value == "$GAS_LIMIT" {
             match target {
-                era_compiler_common::Target::EraVM => {
+                benchmark_analyzer::Target::EraVM => {
                     web3::types::U256::from(SystemContext::BLOCK_GAS_LIMIT_ERAVM)
                 }
-                era_compiler_common::Target::EVM => {
+                benchmark_analyzer::Target::EVM => {
                     web3::types::U256::from(SystemContext::BLOCK_GAS_LIMIT_EVM)
                 }
             }
         } else if value == "$COINBASE" {
             match target {
-                era_compiler_common::Target::EraVM => web3::types::U256::from_str_radix(
+                benchmark_analyzer::Target::EraVM => web3::types::U256::from_str_radix(
                     SystemContext::COIN_BASE_ERAVM,
                     era_compiler_common::BASE_HEXADECIMAL,
                 ),
-                era_compiler_common::Target::EVM => web3::types::U256::from_str_radix(
+                benchmark_analyzer::Target::EVM => web3::types::U256::from_str_radix(
                     SystemContext::COIN_BASE_EVM,
                     era_compiler_common::BASE_HEXADECIMAL,
                 ),
@@ -125,10 +125,10 @@ impl Value {
             web3::types::U256::from(SystemContext::CURRENT_BLOCK_NUMBER)
         } else if value == "$BLOCK_TIMESTAMP" {
             match target {
-                era_compiler_common::Target::EraVM => {
+                benchmark_analyzer::Target::EraVM => {
                     web3::types::U256::from(SystemContext::CURRENT_BLOCK_TIMESTAMP_ERAVM)
                 }
-                era_compiler_common::Target::EVM => {
+                benchmark_analyzer::Target::EVM => {
                     web3::types::U256::from(SystemContext::CURRENT_BLOCK_TIMESTAMP_EVM)
                 }
             }
@@ -146,7 +146,7 @@ impl Value {
     pub fn try_from_vec_matter_labs(
         values: Vec<String>,
         instances: &BTreeMap<String, Instance>,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Vec<Self>> {
         values
             .into_iter()

--- a/compiler_tester/src/test/case/mod.rs
+++ b/compiler_tester/src/test/case/mod.rs
@@ -48,7 +48,7 @@ impl Case {
         mode: &Mode,
         instances: &BTreeMap<String, Instance>,
         method_identifiers: &Option<BTreeMap<String, BTreeMap<String, u32>>>,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Self> {
         let mut inputs = Vec::with_capacity(case.inputs.len());
 
@@ -69,7 +69,7 @@ impl Case {
         case: &[solidity_adapter::FunctionCall],
         instances: BTreeMap<String, Instance>,
         last_source: &str,
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> anyhow::Result<Self> {
         let mut inputs = Vec::with_capacity(case.len());
         let mut caller = solidity_adapter::account_address(solidity_adapter::DEFAULT_ACCOUNT_INDEX);

--- a/compiler_tester/src/vm/eravm/system_context.rs
+++ b/compiler_tester/src/vm/eravm/system_context.rs
@@ -106,25 +106,25 @@ impl SystemContext {
     /// Returns the storage values for the system context.
     ///
     pub fn create_storage(
-        target: era_compiler_common::Target,
+        target: benchmark_analyzer::Target,
     ) -> HashMap<zkevm_tester::compiler_tests::StorageKey, web3::types::H256> {
         let chain_id = match target {
-            era_compiler_common::Target::EraVM => Self::CHAIND_ID_ERAVM,
-            era_compiler_common::Target::EVM => Self::CHAIND_ID_EVM,
+            benchmark_analyzer::Target::EraVM => Self::CHAIND_ID_ERAVM,
+            benchmark_analyzer::Target::EVM => Self::CHAIND_ID_EVM,
         };
         let coinbase = match target {
-            era_compiler_common::Target::EraVM => Self::COIN_BASE_ERAVM,
-            era_compiler_common::Target::EVM => Self::COIN_BASE_EVM,
+            benchmark_analyzer::Target::EraVM => Self::COIN_BASE_ERAVM,
+            benchmark_analyzer::Target::EVM => Self::COIN_BASE_EVM,
         };
 
         let block_number = Self::CURRENT_BLOCK_NUMBER;
         let block_timestamp = match target {
-            era_compiler_common::Target::EraVM => Self::CURRENT_BLOCK_TIMESTAMP_ERAVM,
-            era_compiler_common::Target::EVM => Self::BLOCK_TIMESTAMP_EVM_STEP,
+            benchmark_analyzer::Target::EraVM => Self::CURRENT_BLOCK_TIMESTAMP_ERAVM,
+            benchmark_analyzer::Target::EVM => Self::BLOCK_TIMESTAMP_EVM_STEP,
         };
         let block_gas_limit = match target {
-            era_compiler_common::Target::EraVM => Self::BLOCK_GAS_LIMIT_ERAVM,
-            era_compiler_common::Target::EVM => Self::BLOCK_GAS_LIMIT_EVM,
+            benchmark_analyzer::Target::EraVM => Self::BLOCK_GAS_LIMIT_ERAVM,
+            benchmark_analyzer::Target::EVM => Self::BLOCK_GAS_LIMIT_EVM,
         };
 
         let mut system_context_values = vec![
@@ -206,7 +206,7 @@ impl SystemContext {
             );
         }
 
-        if target == era_compiler_common::Target::EVM {
+        if target == benchmark_analyzer::Target::EVM {
             let rich_addresses: Vec<web3::types::Address> = (0..=9)
                 .map(|address_id| {
                     format!(


### PR DESCRIPTION
# What ❔

Starts splitting EraVM and EVM logic.

## Why ❔

We want to move all EVM testing facilities to the solx monorepo.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
