### PR TITLE
fix: a stupid bug in the gas converter

### DIFF
--- a/benchmark_analyzer/src/model/benchmark/test/toolchain/codegen/versioned/executable/run.rs
+++ b/benchmark_analyzer/src/model/benchmark/test/toolchain/codegen/versioned/executable/run.rs
@@ -44,12 +44,8 @@ impl Run {
                 .iter()
                 .filter(|value| value < &&(u32::MAX as u64)),
         );
-        self.gas.extend(
-            other
-                .ergs
-                .iter()
-                .filter(|value| value < &&(u32::MAX as u64)),
-        );
+        self.gas
+            .extend(other.gas.iter().filter(|value| value < &&(u32::MAX as u64)));
     }
 
     ///


### PR DESCRIPTION
Fixes a stupid typo in the gas converter.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
